### PR TITLE
added exclusion for kasten-io in network-policies

### DIFF
--- a/controllers/default_deny_network_policy.go
+++ b/controllers/default_deny_network_policy.go
@@ -34,6 +34,7 @@ var excludedNamespaces = []string{
 	"gke-system",
 	"resource-group-controller-manager",
 	"vault",
+	"kasten-io",
 }
 
 type DefaultDenyNetworkPolicyReconciler struct {


### PR DESCRIPTION
Pods not starting due to change in network policies, add kasten-io to exclusions while performing PoC. Task added for new network policies for Kasten-io after completion of PoC