### PR TITLE
Flip logic for choosing ingress

### DIFF
--- a/controllers/ingress_gateway.go
+++ b/controllers/ingress_gateway.go
@@ -66,10 +66,10 @@ func (r *IngressGatewayReconciler) Reconcile(ctx context.Context, req reconcile.
 				return err
 			}
 
-			if isExternal(hostname) {
-				gateway.Spec.Selector = map[string]string{"ingress": "external"}
-			} else {
+			if isInternal(hostname) {
 				gateway.Spec.Selector = map[string]string{"ingress": "internal"}
+			} else {
+				gateway.Spec.Selector = map[string]string{"ingress": "external"}
 			}
 
 			gateway.Spec.Servers = make([]*networkingv1beta1api.Server, 2)

--- a/controllers/network_policy.go
+++ b/controllers/network_policy.go
@@ -103,10 +103,10 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req reconcile.R
 		internal := false
 		external := false
 		for _, hostname := range application.Spec.Ingresses {
-			if isExternal(hostname) {
-				external = true
-			} else {
+			if isInternal(hostname) {
 				internal = true
+			} else {
+				external = true
 			}
 		}
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 )
 
-var externalPattern = regexp.MustCompile(`[^.]\.kartverket\.no`)
+var internalPattern = regexp.MustCompile(`[^.]\.skip\.statkart\.no`)
 
-func isExternal(hostname string) bool {
-	return externalPattern.MatchString(hostname)
+func isInternal(hostname string) bool {
+	return internalPattern.MatchString(hostname)
 }


### PR DESCRIPTION
This ensures other external patterns are implicitly supported, like `norgeskart.no`. The only DNS wildcard that is currently pointing to the internal ingress is `*.env.skip.statkart.no`.

The only tradeoff is that the implicit behavior makes it possible to expose things by accident, but I see this as unlikely as that would require pointing DNS to the external dns first.