### PR TITLE
Revert "Use kubernetes probe definition (#30)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ spec:
     failureThreshold: 3
     # Number of seconds after which the probe times out. Defaults to 1 second.
     # Minimum value is 1
-    timeoutSeconds: 1
+    timeout: 1
     # Delay sending the first probe by X seconds. Can be useful for applications that
     # are slow to start.
-    initialDelaySeconds: 0
+    initialDelay: 0
   # Readiness probes define a resource that returns 200 OK when the app is running
   # as intended. Kubernetes will wait until the resource returns 200 OK before
   # marking the pod as Running and progressing with the deployment strategy.

--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -47,11 +47,11 @@ type ApplicationSpec struct {
 	//+kubebuilder:validation:Required
 	Port int `json:"port"`
 	//+kubebuilder:validation:Optional
-	Liveness *corev1.Probe `json:"liveness,omitempty"`
+	Liveness *Probe `json:"liveness,omitempty"`
 	//+kubebuilder:validation:Optional
-	Readiness *corev1.Probe `json:"readiness,omitempty"`
+	Readiness *Probe `json:"readiness,omitempty"`
 	//+kubebuilder:validation:Optional
-	Startup *corev1.Probe `json:"startup,omitempty"`
+	Startup *Probe `json:"startup,omitempty"`
 
 	//+kubebuilder:validation:Optional
 	Ingresses []string `json:"ingresses,omitempty"`
@@ -95,6 +95,20 @@ type FilesFrom struct {
 	EmptyDir string `json:"emptyDir,omitempty"`
 	//+kubebuilder:validation:Optional
 	PersistentVolumeClaim string `json:"persistentVolumeClaim,omitempty"`
+}
+
+type Probe struct {
+	//+kubebuilder:validation:Optional
+	InitialDelay uint `json:"initialDelay,omitempty"`
+	//+kubebuilder:validation:Optional
+	Timeout uint `json:"timeout,omitempty"`
+	//+kubebuilder:validation:Optional
+	FailureThreshold uint `json:"failureThreshold,omitempty"`
+
+	//+kubebuilder:validation:Required
+	Port uint16 `json:"port"`
+	//+kubebuilder:validation:Required
+	Path string `json:"path"`
 }
 
 //+kubebuilder:object:generate=true

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -142,13 +143,34 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		}
 
 		if application.Spec.Readiness != nil {
-			container.ReadinessProbe = application.Spec.Readiness
+			container.ReadinessProbe = &corev1.Probe{}
+			container.ReadinessProbe.InitialDelaySeconds = int32(application.Spec.Readiness.InitialDelay)
+			container.ReadinessProbe.TimeoutSeconds = int32(application.Spec.Readiness.Timeout)
+			container.ReadinessProbe.FailureThreshold = int32(application.Spec.Readiness.FailureThreshold)
+
+			container.ReadinessProbe.HTTPGet = &corev1.HTTPGetAction{}
+			container.ReadinessProbe.HTTPGet.Port = intstr.FromInt(int(application.Spec.Readiness.Port))
+			container.ReadinessProbe.HTTPGet.Path = application.Spec.Readiness.Path
 		}
 		if application.Spec.Liveness != nil {
-			container.LivenessProbe = application.Spec.Liveness
+			container.LivenessProbe = &corev1.Probe{}
+			container.LivenessProbe.InitialDelaySeconds = int32(application.Spec.Liveness.InitialDelay)
+			container.LivenessProbe.TimeoutSeconds = int32(application.Spec.Liveness.Timeout)
+			container.LivenessProbe.FailureThreshold = int32(application.Spec.Liveness.FailureThreshold)
+
+			container.LivenessProbe.HTTPGet = &corev1.HTTPGetAction{}
+			container.LivenessProbe.HTTPGet.Port = intstr.FromInt(int(application.Spec.Liveness.Port))
+			container.LivenessProbe.HTTPGet.Path = application.Spec.Liveness.Path
 		}
 		if application.Spec.Startup != nil {
-			container.StartupProbe = application.Spec.Startup
+			container.StartupProbe = &corev1.Probe{}
+			container.StartupProbe.InitialDelaySeconds = int32(application.Spec.Startup.InitialDelay)
+			container.StartupProbe.TimeoutSeconds = int32(application.Spec.Startup.Timeout)
+			container.StartupProbe.FailureThreshold = int32(application.Spec.Startup.FailureThreshold)
+
+			container.StartupProbe.HTTPGet = &corev1.HTTPGetAction{}
+			container.StartupProbe.HTTPGet.Port = intstr.FromInt(int(application.Spec.Startup.Port))
+			container.StartupProbe.HTTPGet.Path = application.Spec.Startup.Path
 		}
 
 		return nil

--- a/deployment/skiperator.kartverket.no_applications.yaml
+++ b/deployment/skiperator.kartverket.no_applications.yaml
@@ -241,294 +241,38 @@ spec:
                   type: string
                 type: array
               liveness:
-                description: Probe describes a health check to be performed against
-                  a container to determine whether it is alive or ready to receive
-                  traffic.
                 properties:
-                  exec:
-                    description: Exec specifies the action to take.
-                    properties:
-                      command:
-                        description: Command is the command line to execute inside
-                          the container, the working directory for the command  is
-                          root ('/') in the container's filesystem. The command is
-                          simply exec'd, it is not run inside a shell, so traditional
-                          shell instructions ('|', etc) won't work. To use a shell,
-                          you need to explicitly call out to that shell. Exit status
-                          of 0 is treated as live/healthy and non-zero is unhealthy.
-                        items:
-                          type: string
-                        type: array
-                    type: object
                   failureThreshold:
-                    description: Minimum consecutive failures for the probe to be
-                      considered failed after having succeeded. Defaults to 3. Minimum
-                      value is 1.
-                    format: int32
                     type: integer
-                  grpc:
-                    description: GRPC specifies an action involving a GRPC port. This
-                      is a beta field and requires enabling GRPCContainerProbe feature
-                      gate.
-                    properties:
-                      port:
-                        description: Port number of the gRPC service. Number must
-                          be in the range 1 to 65535.
-                        format: int32
-                        type: integer
-                      service:
-                        description: "Service is the name of the service to place
-                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                          \n If this is not specified, the default behavior is defined
-                          by gRPC."
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  httpGet:
-                    description: HTTPGet specifies the http request to perform.
-                    properties:
-                      host:
-                        description: Host name to connect to, defaults to the pod
-                          IP. You probably want to set "Host" in httpHeaders instead.
-                        type: string
-                      httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows
-                          repeated headers.
-                        items:
-                          description: HTTPHeader describes a custom header to be
-                            used in HTTP probes
-                          properties:
-                            name:
-                              description: The header field name
-                              type: string
-                            value:
-                              description: The header field value
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      path:
-                        description: Path to access on the HTTP server.
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Name or number of the port to access on the container.
-                          Number must be in the range 1 to 65535. Name must be an
-                          IANA_SVC_NAME.
-                        x-kubernetes-int-or-string: true
-                      scheme:
-                        description: Scheme to use for connecting to the host. Defaults
-                          to HTTP.
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  initialDelaySeconds:
-                    description: 'Number of seconds after the container has started
-                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    format: int32
+                  initialDelay:
                     type: integer
-                  periodSeconds:
-                    description: How often (in seconds) to perform the probe. Default
-                      to 10 seconds. Minimum value is 1.
-                    format: int32
+                  path:
+                    type: string
+                  port:
                     type: integer
-                  successThreshold:
-                    description: Minimum consecutive successes for the probe to be
-                      considered successful after having failed. Defaults to 1. Must
-                      be 1 for liveness and startup. Minimum value is 1.
-                    format: int32
+                  timeout:
                     type: integer
-                  tcpSocket:
-                    description: TCPSocket specifies an action involving a TCP port.
-                    properties:
-                      host:
-                        description: 'Optional: Host name to connect to, defaults
-                          to the pod IP.'
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Number or name of the port to access on the container.
-                          Number must be in the range 1 to 65535. Name must be an
-                          IANA_SVC_NAME.
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - port
-                    type: object
-                  terminationGracePeriodSeconds:
-                    description: Optional duration in seconds the pod needs to terminate
-                      gracefully upon probe failure. The grace period is the duration
-                      in seconds after the processes running in the pod are sent a
-                      termination signal and the time when the processes are forcibly
-                      halted with a kill signal. Set this value longer than the expected
-                      cleanup time for your process. If this value is nil, the pod's
-                      terminationGracePeriodSeconds will be used. Otherwise, this
-                      value overrides the value provided by the pod spec. Value must
-                      be non-negative integer. The value zero indicates stop immediately
-                      via the kill signal (no opportunity to shut down). This is a
-                      beta field and requires enabling ProbeTerminationGracePeriod
-                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                      is used if unset.
-                    format: int64
-                    type: integer
-                  timeoutSeconds:
-                    description: 'Number of seconds after which the probe times out.
-                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    format: int32
-                    type: integer
+                required:
+                - path
+                - port
                 type: object
               port:
                 type: integer
               readiness:
-                description: Probe describes a health check to be performed against
-                  a container to determine whether it is alive or ready to receive
-                  traffic.
                 properties:
-                  exec:
-                    description: Exec specifies the action to take.
-                    properties:
-                      command:
-                        description: Command is the command line to execute inside
-                          the container, the working directory for the command  is
-                          root ('/') in the container's filesystem. The command is
-                          simply exec'd, it is not run inside a shell, so traditional
-                          shell instructions ('|', etc) won't work. To use a shell,
-                          you need to explicitly call out to that shell. Exit status
-                          of 0 is treated as live/healthy and non-zero is unhealthy.
-                        items:
-                          type: string
-                        type: array
-                    type: object
                   failureThreshold:
-                    description: Minimum consecutive failures for the probe to be
-                      considered failed after having succeeded. Defaults to 3. Minimum
-                      value is 1.
-                    format: int32
                     type: integer
-                  grpc:
-                    description: GRPC specifies an action involving a GRPC port. This
-                      is a beta field and requires enabling GRPCContainerProbe feature
-                      gate.
-                    properties:
-                      port:
-                        description: Port number of the gRPC service. Number must
-                          be in the range 1 to 65535.
-                        format: int32
-                        type: integer
-                      service:
-                        description: "Service is the name of the service to place
-                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                          \n If this is not specified, the default behavior is defined
-                          by gRPC."
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  httpGet:
-                    description: HTTPGet specifies the http request to perform.
-                    properties:
-                      host:
-                        description: Host name to connect to, defaults to the pod
-                          IP. You probably want to set "Host" in httpHeaders instead.
-                        type: string
-                      httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows
-                          repeated headers.
-                        items:
-                          description: HTTPHeader describes a custom header to be
-                            used in HTTP probes
-                          properties:
-                            name:
-                              description: The header field name
-                              type: string
-                            value:
-                              description: The header field value
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      path:
-                        description: Path to access on the HTTP server.
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Name or number of the port to access on the container.
-                          Number must be in the range 1 to 65535. Name must be an
-                          IANA_SVC_NAME.
-                        x-kubernetes-int-or-string: true
-                      scheme:
-                        description: Scheme to use for connecting to the host. Defaults
-                          to HTTP.
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  initialDelaySeconds:
-                    description: 'Number of seconds after the container has started
-                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    format: int32
+                  initialDelay:
                     type: integer
-                  periodSeconds:
-                    description: How often (in seconds) to perform the probe. Default
-                      to 10 seconds. Minimum value is 1.
-                    format: int32
+                  path:
+                    type: string
+                  port:
                     type: integer
-                  successThreshold:
-                    description: Minimum consecutive successes for the probe to be
-                      considered successful after having failed. Defaults to 1. Must
-                      be 1 for liveness and startup. Minimum value is 1.
-                    format: int32
+                  timeout:
                     type: integer
-                  tcpSocket:
-                    description: TCPSocket specifies an action involving a TCP port.
-                    properties:
-                      host:
-                        description: 'Optional: Host name to connect to, defaults
-                          to the pod IP.'
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Number or name of the port to access on the container.
-                          Number must be in the range 1 to 65535. Name must be an
-                          IANA_SVC_NAME.
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - port
-                    type: object
-                  terminationGracePeriodSeconds:
-                    description: Optional duration in seconds the pod needs to terminate
-                      gracefully upon probe failure. The grace period is the duration
-                      in seconds after the processes running in the pod are sent a
-                      termination signal and the time when the processes are forcibly
-                      halted with a kill signal. Set this value longer than the expected
-                      cleanup time for your process. If this value is nil, the pod's
-                      terminationGracePeriodSeconds will be used. Otherwise, this
-                      value overrides the value provided by the pod spec. Value must
-                      be non-negative integer. The value zero indicates stop immediately
-                      via the kill signal (no opportunity to shut down). This is a
-                      beta field and requires enabling ProbeTerminationGracePeriod
-                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                      is used if unset.
-                    format: int64
-                    type: integer
-                  timeoutSeconds:
-                    description: 'Number of seconds after which the probe times out.
-                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    format: int32
-                    type: integer
+                required:
+                - path
+                - port
                 type: object
               replicas:
                 properties:
@@ -568,148 +312,20 @@ spec:
                     type: object
                 type: object
               startup:
-                description: Probe describes a health check to be performed against
-                  a container to determine whether it is alive or ready to receive
-                  traffic.
                 properties:
-                  exec:
-                    description: Exec specifies the action to take.
-                    properties:
-                      command:
-                        description: Command is the command line to execute inside
-                          the container, the working directory for the command  is
-                          root ('/') in the container's filesystem. The command is
-                          simply exec'd, it is not run inside a shell, so traditional
-                          shell instructions ('|', etc) won't work. To use a shell,
-                          you need to explicitly call out to that shell. Exit status
-                          of 0 is treated as live/healthy and non-zero is unhealthy.
-                        items:
-                          type: string
-                        type: array
-                    type: object
                   failureThreshold:
-                    description: Minimum consecutive failures for the probe to be
-                      considered failed after having succeeded. Defaults to 3. Minimum
-                      value is 1.
-                    format: int32
                     type: integer
-                  grpc:
-                    description: GRPC specifies an action involving a GRPC port. This
-                      is a beta field and requires enabling GRPCContainerProbe feature
-                      gate.
-                    properties:
-                      port:
-                        description: Port number of the gRPC service. Number must
-                          be in the range 1 to 65535.
-                        format: int32
-                        type: integer
-                      service:
-                        description: "Service is the name of the service to place
-                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                          \n If this is not specified, the default behavior is defined
-                          by gRPC."
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  httpGet:
-                    description: HTTPGet specifies the http request to perform.
-                    properties:
-                      host:
-                        description: Host name to connect to, defaults to the pod
-                          IP. You probably want to set "Host" in httpHeaders instead.
-                        type: string
-                      httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows
-                          repeated headers.
-                        items:
-                          description: HTTPHeader describes a custom header to be
-                            used in HTTP probes
-                          properties:
-                            name:
-                              description: The header field name
-                              type: string
-                            value:
-                              description: The header field value
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      path:
-                        description: Path to access on the HTTP server.
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Name or number of the port to access on the container.
-                          Number must be in the range 1 to 65535. Name must be an
-                          IANA_SVC_NAME.
-                        x-kubernetes-int-or-string: true
-                      scheme:
-                        description: Scheme to use for connecting to the host. Defaults
-                          to HTTP.
-                        type: string
-                    required:
-                    - port
-                    type: object
-                  initialDelaySeconds:
-                    description: 'Number of seconds after the container has started
-                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    format: int32
+                  initialDelay:
                     type: integer
-                  periodSeconds:
-                    description: How often (in seconds) to perform the probe. Default
-                      to 10 seconds. Minimum value is 1.
-                    format: int32
+                  path:
+                    type: string
+                  port:
                     type: integer
-                  successThreshold:
-                    description: Minimum consecutive successes for the probe to be
-                      considered successful after having failed. Defaults to 1. Must
-                      be 1 for liveness and startup. Minimum value is 1.
-                    format: int32
+                  timeout:
                     type: integer
-                  tcpSocket:
-                    description: TCPSocket specifies an action involving a TCP port.
-                    properties:
-                      host:
-                        description: 'Optional: Host name to connect to, defaults
-                          to the pod IP.'
-                        type: string
-                      port:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Number or name of the port to access on the container.
-                          Number must be in the range 1 to 65535. Name must be an
-                          IANA_SVC_NAME.
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - port
-                    type: object
-                  terminationGracePeriodSeconds:
-                    description: Optional duration in seconds the pod needs to terminate
-                      gracefully upon probe failure. The grace period is the duration
-                      in seconds after the processes running in the pod are sent a
-                      termination signal and the time when the processes are forcibly
-                      halted with a kill signal. Set this value longer than the expected
-                      cleanup time for your process. If this value is nil, the pod's
-                      terminationGracePeriodSeconds will be used. Otherwise, this
-                      value overrides the value provided by the pod spec. Value must
-                      be non-negative integer. The value zero indicates stop immediately
-                      via the kill signal (no opportunity to shut down). This is a
-                      beta field and requires enabling ProbeTerminationGracePeriod
-                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                      is used if unset.
-                    format: int64
-                    type: integer
-                  timeoutSeconds:
-                    description: 'Number of seconds after which the probe times out.
-                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                    format: int32
-                    type: integer
+                required:
+                - path
+                - port
                 type: object
               strategy:
                 properties:


### PR DESCRIPTION
Dette skapte masse krøll med eksisterende terraform state som har cachet CRD-en og med at det også endrer på API-et for `path` og `port`. Vi må få opp sandbox-miljøet først og få testet dette ordentlig og laget en migrasjonssti for brukerene