### PR TITLE
Set default value for external ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ spec:
       rules:
       - application: other-app
       # external specifies which applications on the internet the application
-      # can reach. Only host is required unless it is on another port than HTTP
-      # on port 80 and HTTPS on port 443. If other ports or protocols are
-      # required then port must be specified as well
+      # can reach. Only host is required unless it is on another port than HTTPS
+      # on port 443. If other ports or protocols are required then `ports` must
+      # be specified as well
       external:
         # The allowed hostname. Note that this does not include subdomains
       - host: nrk.no

--- a/controllers/egress_service_entry.go
+++ b/controllers/egress_service_entry.go
@@ -3,8 +3,10 @@ package controllers
 import (
 	"context"
 	"fmt"
-	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"hash/fnv"
+	"strings"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strings"
 )
 
 //+kubebuilder:rbac:groups=skiperator.kartverket.no,resources=applications,verbs=get;list;watch
@@ -77,17 +78,13 @@ func (r *EgressServiceEntryReconciler) Reconcile(ctx context.Context, applicatio
 
 			ports := rule.Ports
 
-			// When not specified default to opening HTTP and HTTPS
+			// When not specified default to opening HTTPS
 			if len(ports) == 0 {
-				ports = make([]*networkingv1beta1api.Port, 2)
+				ports = make([]skiperatorv1alpha1.Port, 1)
 
-				ports[0].Name = "http"
-				ports[0].Number = 80
+				ports[0].Name = "https"
+				ports[0].Port = 443
 				ports[0].Protocol = "HTTPS"
-
-				ports[1].Name = "https"
-				ports[1].Number = 443
-				ports[1].Protocol = "HTTPS"
 			}
 
 			serviceEntry.Spec.Ports = make([]*networkingv1beta1api.Port, len(ports))

--- a/controllers/egress_service_entry.go
+++ b/controllers/egress_service_entry.go
@@ -75,8 +75,23 @@ func (r *EgressServiceEntryReconciler) Reconcile(ctx context.Context, applicatio
 				serviceEntry.Spec.Endpoints = []*networkingv1beta1api.WorkloadEntry{{Address: rule.Ip}}
 			}
 
-			serviceEntry.Spec.Ports = make([]*networkingv1beta1api.Port, len(rule.Ports))
-			for i, port := range rule.Ports {
+			ports := rule.Ports
+
+			// When not specified default to opening HTTP and HTTPS
+			if len(ports) == 0 {
+				ports = make([]*networkingv1beta1api.Port, 2)
+
+				ports[0].Name = "http"
+				ports[0].Number = 80
+				ports[0].Protocol = "HTTPS"
+
+				ports[1].Name = "https"
+				ports[1].Number = 443
+				ports[1].Protocol = "HTTPS"
+			}
+
+			serviceEntry.Spec.Ports = make([]*networkingv1beta1api.Port, len(ports))
+			for i, port := range ports {
 				if rule.Ip == "" && port.Protocol == "TCP" {
 					r.recorder.Eventf(
 						application,

--- a/tests/access-policy/00-application.yaml
+++ b/tests/access-policy/00-application.yaml
@@ -20,3 +20,4 @@ spec:
         - name: http
           port: 80
           protocol: HTTP
+      - host: foo.com

--- a/tests/access-policy/00-assert.yaml
+++ b/tests/access-policy/00-assert.yaml
@@ -43,5 +43,21 @@ spec:
   - example.com
   ports:
   - name: http
+    number: 802
+    protocol: HTTP
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: test-egress-03a90cb5d70dc06a
+spec:
+  exportTo:
+  - .
+  - istio-system
+  resolution: DNS
+  hosts:
+  - foo.com
+  ports:
+  - name: http
     number: 80
     protocol: HTTP

--- a/tests/access-policy/00-assert.yaml
+++ b/tests/access-policy/00-assert.yaml
@@ -43,13 +43,13 @@ spec:
   - example.com
   ports:
   - name: http
-    number: 802
+    number: 80
     protocol: HTTP
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
-  name: test-egress-03a90cb5d70dc06a
+  name: test-egress-3a90cb5d70dc06a
 spec:
   exportTo:
   - .
@@ -58,6 +58,6 @@ spec:
   hosts:
   - foo.com
   ports:
-  - name: http
-    number: 80
-    protocol: HTTP
+  - name: https
+    number: 443
+    protocol: HTTPS


### PR DESCRIPTION
It's currently documented that we support external allowlisting of hosts without specifying port. This was not the case because it created ServiceEntry files with no port, which is not supported.

Not specifying ports now implicitly creates a HTTPS port opening. Does not open HTTP as a nudge towards using HTTPS everywhere, that must be set manually.