### PR TITLE
exclude kubecost

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -38,6 +38,7 @@ var excludedNamespaces = []string{
 	"sysdig-agent",
 	"sysdig-admission-controller",
 	"instana-agent",
+	"kubecost",
 }
 
 func isNotExcludedNamespace(namespace *corev1.Namespace) bool {


### PR DESCRIPTION
Kubecost blir blokkert av default deny.  
Kan sette den på exclude inntil vi har testet ferdig og kan utrede hvilke nettverksregler som trengs.