### PR TITLE
Forcibly override field manager for clusterrole too

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -21,4 +21,8 @@ resource "kubernetes_manifest" "custom_resource_definition" {
 
 resource "kubernetes_manifest" "cluster_role" {
   manifest = yamldecode(file("${path.module}/role.yaml"))
+
+  field_manager {
+    force_conflicts = true
+  }
 }


### PR DESCRIPTION
Fixes faulty deploy in develop env due to local skiperator run in the wrong context. See #98 for solution to the underlying problem.