### PR TITLE
Add support for Google Secret Manager Provider for Secret Store CSI Driver

### DIFF
--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -110,6 +110,8 @@ type EnvFrom struct {
 	ConfigMap string `json:"configMap,omitempty"`
 	//+kubebuilder:validation:Optional
 	Secret string `json:"secret,omitempty"`
+	//+kubebuilder:validation:Optional
+	GcpSecretManager string `json:"gcpSecretManager,omitempty"`
 }
 
 type FilesFrom struct {
@@ -124,6 +126,8 @@ type FilesFrom struct {
 	EmptyDir string `json:"emptyDir,omitempty"`
 	//+kubebuilder:validation:Optional
 	PersistentVolumeClaim string `json:"persistentVolumeClaim,omitempty"`
+	//+kubebuilder:validation:Optional
+	GcpSecretManager string `json:"gcpSecretManager,omitempty"`
 }
 
 type Probe struct {

--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	secretsStorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
@@ -43,6 +44,7 @@ func init() {
 	utilruntime.Must(securityv1beta1.AddToScheme(scheme))
 	utilruntime.Must(networkingv1beta1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
+	utilruntime.Must(secretsStorev1.AddToScheme(scheme))
 }
 
 func main() {

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -35,6 +35,7 @@ import (
 // +kubebuilder:rbac:groups=security.istio.io,resources=peerauthentications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses,verbs=get;list;watch;create;update;patch;delete
 
 type ApplicationReconciler struct {
 	util.ReconcilerBase

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -158,6 +158,11 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		return reconcile.Result{}, err
 	}
 
+	_, err = r.reconcileSecretProviderClass(ctx, application)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	isApplicationMarkedToBeDeleted := application.GetDeletionTimestamp() != nil
 	if isApplicationMarkedToBeDeleted {
 		if ctrlutil.ContainsFinalizer(application, applicationFinalizer) {

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	secretsStorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=applications;applications/status,verbs=get;list;watch;update
@@ -60,6 +61,7 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&securityv1beta1.PeerAuthentication{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&networkingv1.NetworkPolicy{}).
+		Owns(&secretsStorev1.SecretProviderClass{}).
 		Watches(
 			&source.Kind{Type: &certmanagerv1.Certificate{}},
 			handler.EnqueueRequestsFromMapFunc(r.SkiperatorOwnedCertRequests),

--- a/controllers/application/secret_provider_class.go
+++ b/controllers/application/secret_provider_class.go
@@ -43,6 +43,14 @@ func (r *ApplicationReconciler) reconcileSecretProviderClass(ctx context.Context
 
 		secretProviderClass := secretsStorev1.SecretProviderClass{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: name}}
 		_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &secretProviderClass, func() error {
+			err := ctrlutil.SetControllerReference(application, &secretProviderClass, r.GetScheme())
+			if err != nil {
+				r.SetControllerError(ctx, application, controllerName, err)
+				return err
+			}
+
+			r.SetLabelsFromApplication(ctx, &secretProviderClass, *application)
+
 			secretProviderClass.Spec.Provider = "gcp"
 			// Create mapping for secret in GCP to path in kubernetes
 			secretProviderClass.Spec.Parameters = map[string]string{

--- a/controllers/application/secret_provider_class.go
+++ b/controllers/application/secret_provider_class.go
@@ -1,0 +1,65 @@
+package applicationcontroller
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	secretsStore "sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
+)
+
+func (r *ApplicationReconciler) reconcileSecretProviderClass(ctx context.Context, application *skiperatorv1alpha1.Application) (reconcile.Result, error) {
+	controllerName := "SecretProviderClass"
+	r.SetControllerProgressing(ctx, application, controllerName)
+
+	var err error
+
+	var secretManagerReferences []string
+	for _, file := range application.Spec.FilesFrom {
+		value := file.GcpSecretManager
+		if len(value) > 0 && !contains(secretManagerReferences, value) {
+			secretManagerReferences = append(secretManagerReferences, value)
+		}
+	}
+	for _, env := range application.Spec.EnvFrom {
+		value := env.GcpSecretManager
+		if len(value) > 0 && !contains(secretManagerReferences, value) {
+			secretManagerReferences = append(secretManagerReferences, value)
+		}
+	}
+
+	for _, secretManagerReference := range secretManagerReferences {
+		hash := fnv.New64()
+		_, _ = hash.Write([]byte(secretManagerReference))
+		name := fmt.Sprintf("%s-%x", application.Name, hash.Sum64())
+
+		// projects/$PROJECT_ID/secrets/testsecret/versions/latest
+		secretName := strings.Split(secretManagerReference, "/")[3]
+
+		secretProviderClass := secretsStore.SecretProviderClass{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: name}}
+		_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &secretProviderClass, func() error {
+			secretProviderClass.Spec.Parameters = map[string]string{
+				"secrets": fmt.Sprintf("|\n  - resourceName: \"%s\"\n    path: \"%s.txt\"", secretManagerReference, secretName),
+			}
+			return nil
+		})
+	}
+
+	r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+
+	return reconcile.Result{}, err
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/deployment/deployment.tf
+++ b/deployment/deployment.tf
@@ -8,7 +8,7 @@ resource "kubernetes_deployment_v1" "deployment" {
     name      = "skiperator"
   }
   spec {
-    replicas = 3
+    replicas = 2
     selector {
       match_labels = {
         app = "skiperator"

--- a/deployment/role.yaml
+++ b/deployment/role.yaml
@@ -129,6 +129,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security.istio.io
   resources:
   - peerauthentications

--- a/deployment/skiperator.kartverket.no_applications.yaml
+++ b/deployment/skiperator.kartverket.no_applications.yaml
@@ -217,6 +217,8 @@ spec:
                   properties:
                     configMap:
                       type: string
+                    gcpSecretManager:
+                      type: string
                     secret:
                       type: string
                   type: object
@@ -227,6 +229,8 @@ spec:
                     configMap:
                       type: string
                     emptyDir:
+                      type: string
+                    gcpSecretManager:
                       type: string
                     mountPath:
                       type: string

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v0.26.0
 	sigs.k8s.io/controller-runtime v0.14.1
 	sigs.k8s.io/controller-tools v0.11.1
+	sigs.k8s.io/secrets-store-csi-driver v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -960,6 +960,8 @@ sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.17.0 h1:CScmGz/wX66puA06Gj8OZb76Wmk7JIjgWf5JDvY7msM=
 sigs.k8s.io/kind v0.17.0/go.mod h1:Qqp8AiwOlMZmJWs37Hgs31xcbiYXjtXlRBSftcnZXQk=
+sigs.k8s.io/secrets-store-csi-driver v1.3.0 h1:9H1lW9Fbnt5mxyMiS5gJ8853SnX8anFUw+ayl4CcVw0=
+sigs.k8s.io/secrets-store-csi-driver v1.3.0/go.mod h1:ANyIQ1Jckd3OjLLhKq4OtF4BeqiJY68Oa3a/DRWlxcA=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -55,3 +55,12 @@ func GenerateHashFromName(name string) uint64 {
 	_, _ = hash.Write([]byte(name))
 	return hash.Sum64()
 }
+
+func Contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/apiserver.conf
+++ b/tests/apiserver.conf
@@ -1,0 +1,12 @@
+--advertise-address=127.0.0.1
+--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}
+--cert-dir={{ .CertDir }}
+--insecure-port={{ if .URL }}{{ .URL.Port }}{{else}}0{{ end }}
+{{ if .URL }}--insecure-bind-address={{ .URL.Hostname }}{{ end }}
+--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}
+--disable-admission-plugins=ServiceAccount
+--service-cluster-ip-range=10.0.0.0/24
+--allow-privileged=true
+--service-account-issuer=https://kubernetes.default.svc.cluster.local
+--service-account-key-file={{ .CertDir }}/apiserver.crt
+--service-account-signing-key-file={{ .CertDir }}/apiserver.key

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -8,6 +8,11 @@ commands:
   - command: kubectl delete validatingwebhookconfiguration cert-manager-webhook
   - command: kubectl delete mutatingwebhookconfiguration cert-manager-webhook
 
+  - command: kubectl apply --filename https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+  - command: kubectl apply --filename https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+  - command: kubectl apply --filename https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/main/deploy/role-secretproviderclasses-admin.yaml
+  - command: kubectl create clusterrolebinding skiperator-secret-store-admin --clusterrole secretproviderclasses-admin-role --serviceaccount test:skiperator
+
   - command: kubectl apply --filename deployment
   - command: kubectl create namespace skiperator-system
   - command: kubectl create configmap gcp-identity-config --from-literal="workloadIdentityPool=testPool" --from-literal="identityProvider=testProvider" -n skiperator-system

--- a/tests/gcp-secret-provider-only-env/00-application.yaml
+++ b/tests/gcp-secret-provider-only-env/00-application.yaml
@@ -1,0 +1,9 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: gcp-secret-provider-only-env
+spec:
+  image: image
+  port: 8080
+  envFrom:
+    - gcpSecretManager: projects/foobar-dev-123/secrets/testsecret/versions/latest

--- a/tests/gcp-secret-provider-only-env/00-assert.yaml
+++ b/tests/gcp-secret-provider-only-env/00-assert.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcp-secret-provider-only-env
+spec:
+  template:
+    spec:
+      containers:
+        - envFrom:
+          - secretRef:
+              name: gcp-sm-testsecret
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+      volumes:
+        - emptyDir: {}
+          name: tmp
+        - name: gcp-sm-6e5548c4eb2bb81f
+          csi:
+            driver: "secrets-store.csi.k8s.io"
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: gcp-secret-provider-only-env-6e5548c4eb2bb81f
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-secret-provider-only-env-6e5548c4eb2bb81f
+spec:
+  provider: gcp
+  parameters:
+    secrets: |-
+      - resourceName: "projects/foobar-dev-123/secrets/testsecret/versions/latest"
+        path: "testsecret"
+        objectAlias: "secretalias"
+  secretObjects:
+  - data:
+    - key: testsecret
+      objectName: secretalias
+    secretName: gcp-sm-testsecret
+    type: Opaque
+    labels:
+      app.kubernetes.io/managed-by: skiperator

--- a/tests/gcp-secret-provider/00-application.yaml
+++ b/tests/gcp-secret-provider/00-application.yaml
@@ -1,0 +1,12 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: gcp-secret-provider
+spec:
+  image: image
+  port: 8080
+  envFrom:
+    - gcpSecretProvider: projects/foobar-dev-123/secrets/testsecret/versions/latest
+  filesFrom:
+    - mountPath: /secretmanager
+      gcpSecretProvider: projects/foobar-dev-123/secrets/testsecret/versions/latest

--- a/tests/gcp-secret-provider/00-application.yaml
+++ b/tests/gcp-secret-provider/00-application.yaml
@@ -6,7 +6,7 @@ spec:
   image: image
   port: 8080
   envFrom:
-    - gcpSecretProvider: projects/foobar-dev-123/secrets/testsecret/versions/latest
+    - gcpSecretManager: projects/foobar-dev-123/secrets/testsecret/versions/latest
   filesFrom:
     - mountPath: /secretmanager
-      gcpSecretProvider: projects/foobar-dev-123/secrets/testsecret/versions/latest
+      gcpSecretManager: projects/foobar-dev-123/secrets/testsecret/versions/latest

--- a/tests/gcp-secret-provider/00-assert.yaml
+++ b/tests/gcp-secret-provider/00-assert.yaml
@@ -2,19 +2,45 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gcp
+  name: gcp-secret-provider
 spec:
   template:
     spec:
       containers:
-        - volumeMounts:
-            - mountPath: /secretmanager
-              name: gcp-secret-provider-dfigjklasdkfjl
+        - envFrom:
+          - secretRef:
+              name: gcp-sm-testsecret
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+          - mountPath: /secretmanager
+            name: gcp-sm-6e5548c4eb2bb81f
       volumes:
-        - name: gcp-secret-provider-dfigjklasdkfjl
+        - emptyDir: {}
+          name: tmp
+        - name: gcp-sm-6e5548c4eb2bb81f
           csi:
             driver: "secrets-store.csi.k8s.io"
             readOnly: true
-            secretProviderClass:
-              name: gcp-secret-provider-dfigjklasdkfjl
+            volumeAttributes:
+              secretProviderClass: gcp-secret-provider-6e5548c4eb2bb81f
 ---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-secret-provider-6e5548c4eb2bb81f
+spec:
+  provider: gcp
+  parameters:
+    secrets: |-
+      - resourceName: "projects/foobar-dev-123/secrets/testsecret/versions/latest"
+        path: "testsecret"
+        objectAlias: "secretalias"
+  secretObjects:
+  - data:
+    - key: testsecret
+      objectName: secretalias
+    secretName: gcp-sm-testsecret
+    type: Opaque
+    labels:
+      app.kubernetes.io/managed-by: skiperator

--- a/tests/gcp-secret-provider/00-assert.yaml
+++ b/tests/gcp-secret-provider/00-assert.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcp
+spec:
+  template:
+    spec:
+      containers:
+        - volumeMounts:
+            - mountPath: /secretmanager
+              name: gcp-secret-provider-dfigjklasdkfjl
+      volumes:
+        - name: gcp-secret-provider-dfigjklasdkfjl
+          csi:
+            driver: "secrets-store.csi.k8s.io"
+            readOnly: true
+            secretProviderClass:
+              name: gcp-secret-provider-dfigjklasdkfjl
+---


### PR DESCRIPTION
Adds the following fields to the Skiperator API:

```
  # Inject to environment variables
  envFrom:
    - gcpSecretManager: projects/35219343203/secrets/test-secret 
  # Inject as file on filesystem
  filesFrom:
    - gcpSecretManager: projects/35219343203/secrets/test-secret
      mountPath: /var/run/secret
```

Adding any of these will mount a special CSI volume to the container which will trigger the GSM CSI driver to fetch the secret for GSM using the pod's workload identity. 

It also creates a matching kubernetes secret object used when mounting as env vars.