### PR TITLE
[SKIP-895] Aggregate labels instead of overriding them on application init

### DIFF
--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -5,6 +5,7 @@ import (
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"golang.org/x/exp/maps"
 
 	util "github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -189,7 +190,15 @@ func (r *ApplicationReconciler) initializeApplication(ctx context.Context, appli
 	if !ctrlutil.ContainsFinalizer(application, applicationFinalizer) {
 		ctrlutil.AddFinalizer(application, applicationFinalizer)
 	}
-	application.Labels = application.Spec.Labels
+
+	currentLabels := application.Labels
+	if len(currentLabels) == 0 {
+		application.Labels = application.Spec.Labels
+	} else {
+		aggregateLabels := currentLabels
+		maps.Copy(aggregateLabels, application.Spec.Labels)
+		application.Labels = aggregateLabels
+	}
 
 	err := r.GetClient().Update(ctx, application)
 	if err != nil {


### PR DESCRIPTION
Labels set by for example argo-cd were overridden due to how Skiperator initialized these labels. With this change one may add labels to an application manually, and it will not be overridden upon reconciliation of the application.

This does however mean no set labels will ever be deleted, unless the whole application resource is deleted, which could potentially lead to bloat. I see no efficient way of knowing whether or not a label should stay or if its stale, other than having a list of labels to check against somewhere. This seems like a subpar solution, so I think potential label bloat is a better trade-off.