### PR TITLE
Omitempty for internalrules

### DIFF
--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -164,7 +164,7 @@ type OutboundPolicy struct {
 
 type InternalRule struct {
 	//+kubebuilder:validation:Optional
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	//+kubebuilder:validation:Required
 	Application string `json:"application"`
 }
@@ -174,7 +174,7 @@ type ExternalRule struct {
 	//+kubebuilder:validation:Required
 	Host string `json:"host"`
 	//+kubebuilder:validation:Optional
-	Ip string `json:"ip"`
+	Ip string `json:"ip,omitempty"`
 	//+kubebuilder:validation:Optional
 	Ports []Port `json:"ports,omitempty"`
 }

--- a/samples/application.yaml
+++ b/samples/application.yaml
@@ -18,8 +18,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - namespace: sample
-          application: sample-two
+        - application: sample-two
     outbound:
       rules:
         - namespace: sample


### PR DESCRIPTION
omitempty being omitted _(hehe)_ caused the namespace field to be populated even though no namespace was present. This forced a diff in ArgoCD and was requested fixed by @esphen 