### PR TITLE
exclude instana-autotrace-webhook

### DIFF
--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -44,6 +44,7 @@ var excludedNamespaces = []string{
 	"argocd",
 	"crossplane-system",
 	"upbound-system",
+	"instana-autotrace-webhook",
 }
 
 func IsNotExcludedNamespace(namespace *corev1.Namespace) bool {


### PR DESCRIPTION
add instana-autotrace-webhook to list of excluded namespaces so Skiperator won't pick it up