### PR TITLE
SKIP-943: expose optional metricsPort for certain applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /kubeconfig
 
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ spec:
   image: "kartverket/example"
   # The port the deployment exposes
   port: 8080
+  # An optional extra port to expose a metrics endpoint through
+  # so the APM toolstack can reach it
+  metricsPort: 8181
   # Override the command set in the Dockerfile. Usually only used when debugging
   # or running third-party containers where you don't have control over the Dockerfile
   command:

--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -55,6 +55,8 @@ type ApplicationSpec struct {
 	//+kubebuilder:validation:Required
 	Port int `json:"port"`
 	//+kubebuilder:validation:Optional
+	MetricsPort int `json:"metricsPort,omitempty"`
+	//+kubebuilder:validation:Optional
 	Liveness *Probe `json:"liveness,omitempty"`
 	//+kubebuilder:validation:Optional
 	Readiness *Probe `json:"readiness,omitempty"`

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -91,6 +91,11 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 
 		container.Ports = make([]corev1.ContainerPort, 1)
 		container.Ports[0].ContainerPort = int32(application.Spec.Port)
+		if application.Spec.MetricsPort != 0 {
+			var metrics = int32(application.Spec.MetricsPort)
+			container.Ports = append(container.Ports, corev1.ContainerPort{ContainerPort: metrics})
+
+		}
 
 		//Adding env for GCP authentication
 		if application.Spec.GCP != nil {

--- a/tests/metrics-port/00-application.yaml
+++ b/tests/metrics-port/00-application.yaml
@@ -1,0 +1,8 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: metrics-port
+spec:
+  image: image
+  port: 8080
+  metricsPort: 8181

--- a/tests/metrics-port/00-assert.yaml
+++ b/tests/metrics-port/00-assert.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-port
+spec:
+  selector:
+    matchLabels:
+      app: metrics-port
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      labels:
+        app: metrics-port
+    spec:
+      containers:
+        - name: metrics-port
+          image: image
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8181
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 150
+            runAsUser: 150
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      imagePullSecrets:
+        - name: github-auth
+      securityContext:
+        fsGroup: 150
+        supplementalGroups:
+          - 150
+      serviceAccountName: metrics-port
+      volumes:
+        - emptyDir: {}
+          name: tmp
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metrics-port
+spec:
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metrics-port
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-port
+spec:
+  selector:
+    app: metrics-port
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+      appProtocol: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: metrics-port
+spec:
+  podSelector:
+    matchLabels:
+      app: metrics-port
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: metrics-port
+spec:
+  selector:
+    matchLabels:
+      app: metrics-port
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
Lets applications expose an optional extra port in those cases where we want a metrics endpoint available through a different port than the standard one.