### PR TITLE
Stop argo pruning skiperator owned resources

### DIFF
--- a/controllers/application/configmap.go
+++ b/controllers/application/configmap.go
@@ -58,6 +58,9 @@ func (r *ApplicationReconciler) reconcileConfigMap(ctx context.Context, applicat
 			return err
 		}
 		r.SetLabelsFromApplication(ctx, &gcpAuthConfigMap, *application)
+		gcpAuthConfigMap.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
 
 		if application.Spec.GCP != nil {
 			ConfStruct := Config{

--- a/controllers/application/configmap.go
+++ b/controllers/application/configmap.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,9 +59,7 @@ func (r *ApplicationReconciler) reconcileConfigMap(ctx context.Context, applicat
 			return err
 		}
 		r.SetLabelsFromApplication(ctx, &gcpAuthConfigMap, *application)
-		gcpAuthConfigMap.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		gcpAuthConfigMap.ObjectMeta.Annotations = util.CommonAnnotations
 
 		if application.Spec.GCP != nil {
 			ConfStruct := Config{

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -44,7 +44,13 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 
 		r.SetLabelsFromApplication(ctx, &deployment, *application)
 
-		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{"prometheus.io/scrape": "true"}
+		deployment.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
+		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+			"prometheus.io/scrape": "true",
+		}
 
 		labels := map[string]string{"app": application.Name}
 		deployment.Spec.Template.ObjectMeta.Labels = labels

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -2,7 +2,9 @@ package applicationcontroller
 
 import (
 	"context"
+
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -44,12 +46,10 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 
 		r.SetLabelsFromApplication(ctx, &deployment, *application)
 
-		deployment.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		deployment.ObjectMeta.Annotations = util.CommonAnnotations
 		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
 			"argocd.argoproj.io/sync-options": "Prune=false",
-			"prometheus.io/scrape": "true",
+			"prometheus.io/scrape":            "true",
 		}
 
 		labels := map[string]string{"app": application.Name}

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -33,6 +33,9 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 				return err
 			}
 			r.SetLabelsFromApplication(ctx, &serviceEntry, *application)
+			serviceEntry.ObjectMeta.Annotations = map[string]string{
+				"argocd.argoproj.io/sync-options": "Prune=false",
+			}
 
 			// Avoid leaking service entry to other namespaces
 			serviceEntry.Spec.ExportTo = []string{".", "istio-system"}

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -33,9 +33,7 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 				return err
 			}
 			r.SetLabelsFromApplication(ctx, &serviceEntry, *application)
-			serviceEntry.ObjectMeta.Annotations = map[string]string{
-				"argocd.argoproj.io/sync-options": "Prune=false",
-			}
+			serviceEntry.ObjectMeta.Annotations = util.CommonAnnotations
 
 			// Avoid leaking service entry to other namespaces
 			serviceEntry.Spec.ExportTo = []string{".", "istio-system"}

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -24,6 +24,9 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 		}
 
 		r.SetLabelsFromApplication(ctx, &horizontalPodAutoscaler, *application)
+		horizontalPodAutoscaler.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
 
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.APIVersion = "apps/v1"
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.Kind = "Deployment"

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,9 +25,7 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 		}
 
 		r.SetLabelsFromApplication(ctx, &horizontalPodAutoscaler, *application)
-		horizontalPodAutoscaler.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		horizontalPodAutoscaler.ObjectMeta.Annotations = util.CommonAnnotations
 
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.APIVersion = "apps/v1"
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.Kind = "Deployment"

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -35,6 +35,9 @@ func (r *ApplicationReconciler) reconcileIngressGateway(ctx context.Context, app
 			}
 
 			r.SetLabelsFromApplication(ctx, &gateway, *application)
+			gateway.ObjectMeta.Annotations = map[string]string{
+				"argocd.argoproj.io/sync-options": "Prune=false",
+			}
 
 			if util.IsInternal(hostname) {
 				gateway.Spec.Selector = map[string]string{"ingress": "internal"}

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -35,9 +35,7 @@ func (r *ApplicationReconciler) reconcileIngressGateway(ctx context.Context, app
 			}
 
 			r.SetLabelsFromApplication(ctx, &gateway, *application)
-			gateway.ObjectMeta.Annotations = map[string]string{
-				"argocd.argoproj.io/sync-options": "Prune=false",
-			}
+			gateway.ObjectMeta.Annotations = util.CommonAnnotations
 
 			if util.IsInternal(hostname) {
 				gateway.Spec.Selector = map[string]string{"ingress": "internal"}

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -31,6 +31,9 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 			}
 
 			r.SetLabelsFromApplication(ctx, &virtualService, *application)
+			virtualService.ObjectMeta.Annotations = map[string]string{
+				"argocd.argoproj.io/sync-options": "Prune=false",
+			}
 
 			gateways := make([]string, 0, len(application.Spec.Ingresses))
 			for _, hostname := range application.Spec.Ingresses {

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,9 +32,7 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 			}
 
 			r.SetLabelsFromApplication(ctx, &virtualService, *application)
-			virtualService.ObjectMeta.Annotations = map[string]string{
-				"argocd.argoproj.io/sync-options": "Prune=false",
-			}
+			virtualService.ObjectMeta.Annotations = util.CommonAnnotations
 
 			gateways := make([]string, 0, len(application.Spec.Ingresses))
 			for _, hostname := range application.Spec.Ingresses {

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -58,6 +58,9 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		}
 
 		r.SetLabelsFromApplication(ctx, &networkPolicy, *application)
+		networkPolicy.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
 
 		labels := map[string]string{"app": application.Name}
 		networkPolicy.Spec.PodSelector.MatchLabels = labels

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -58,9 +58,7 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		}
 
 		r.SetLabelsFromApplication(ctx, &networkPolicy, *application)
-		networkPolicy.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		networkPolicy.ObjectMeta.Annotations = util.CommonAnnotations
 
 		labels := map[string]string{"app": application.Name}
 		networkPolicy.Spec.PodSelector.MatchLabels = labels

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -26,6 +26,9 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 		}
 
 		r.SetLabelsFromApplication(ctx, &peerAuthentication, *application)
+		peerAuthentication.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
 
 		peerAuthentication.Spec.Selector = &typev1beta1.WorkloadSelector{}
 		labels := map[string]string{"app": application.Name}

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
 	securityv1beta1api "istio.io/api/security/v1beta1"
 	typev1beta1 "istio.io/api/type/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -26,9 +27,7 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 		}
 
 		r.SetLabelsFromApplication(ctx, &peerAuthentication, *application)
-		peerAuthentication.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		peerAuthentication.ObjectMeta.Annotations = util.CommonAnnotations
 
 		peerAuthentication.Spec.Selector = &typev1beta1.WorkloadSelector{}
 		labels := map[string]string{"app": application.Name}

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -25,6 +25,9 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		}
 
 		r.SetLabelsFromApplication(ctx, &service, *application)
+		service.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
 
 		labels := map[string]string{"app": application.Name}
 		service.Spec.Selector = labels

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -25,9 +26,7 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		}
 
 		r.SetLabelsFromApplication(ctx, &service, *application)
-		service.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		service.ObjectMeta.Annotations = util.CommonAnnotations
 
 		labels := map[string]string{"app": application.Name}
 		service.Spec.Selector = labels

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -24,6 +24,9 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 		}
 
 		r.SetLabelsFromApplication(ctx, &serviceAccount, *application)
+		serviceAccount.ObjectMeta.Annotations = map[string]string{
+			"argocd.argoproj.io/sync-options": "Prune=false",
+		}
 
 		return nil
 	})

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,9 +25,7 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 		}
 
 		r.SetLabelsFromApplication(ctx, &serviceAccount, *application)
-		serviceAccount.ObjectMeta.Annotations = map[string]string{
-			"argocd.argoproj.io/sync-options": "Prune=false",
-		}
+		serviceAccount.ObjectMeta.Annotations = util.CommonAnnotations
 
 		return nil
 	})

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,0 +1,5 @@
+package util
+
+var CommonAnnotations = map[string]string{
+	"argocd.argoproj.io/sync-options": "Prune=false",
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,5 +1,8 @@
 package util
 
 var CommonAnnotations = map[string]string{
+	// Prevents Argo CD from deleting these resources and leaving the namespace
+	// in a deadlocked deleting state
+	// https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources
 	"argocd.argoproj.io/sync-options": "Prune=false",
 }

--- a/tests/minimal/00-assert.yaml
+++ b/tests/minimal/00-assert.yaml
@@ -7,6 +7,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minimal
+  annotations:
+    argocd.argoproj.io/sync-options: "Prune=false"
 spec:
   selector:
     matchLabels:
@@ -15,6 +17,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        argocd.argoproj.io/sync-options: "Prune=false"
       labels:
         app: minimal
     spec:


### PR DESCRIPTION
When Argo and Skiperator run in the same system they conflict when tearing down a namespace. This PR tells Argo not to touch skiperator app generated resources so namespaces don't get into an infinite terminating state.

Uses this annotation: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources

Tested in sandbox. Seems to work.