### PR TITLE
[SKIP-983] Add common annotation util

### DIFF
--- a/controllers/application/certificate.go
+++ b/controllers/application/certificate.go
@@ -7,7 +7,7 @@ import (
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -7,7 +7,7 @@ import (
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"golang.org/x/exp/maps"
 
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -46,7 +46,7 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 		}
 
 		r.SetLabelsFromApplication(ctx, &deployment, *application)
-		util.SetCommonAnnotations(ctx, &deployment)
+		util.SetCommonAnnotations(&deployment)
 
 		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
 			"argocd.argoproj.io/sync-options": "Prune=false",

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +46,7 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 		}
 
 		r.SetLabelsFromApplication(ctx, &deployment, *application)
-		r.SetCommonAnnotations(ctx, &deployment, *application)
+		util.SetCommonAnnotations(ctx, &deployment)
 
 		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
 			"argocd.argoproj.io/sync-options": "Prune=false",

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -2,7 +2,6 @@ package applicationcontroller
 
 import (
 	"context"
-	"encoding/json"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,15 +35,6 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 	}
 
 	deployment := appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
-
-	deploymentTest := appsv1.Deployment{}
-	errr := r.GetClient().Get(ctx, types.NamespacedName{Namespace: application.Namespace, Name: application.Name}, &deploymentTest)
-	if errr != nil {
-		println(errr.Error())
-	}
-	j, _ := json.MarshalIndent(deploymentTest, "", "\t")
-	println("BEFORE")
-	println(string(j))
 
 	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &deployment, func() error {
 		// Set application as owner of the deployment
@@ -241,10 +231,6 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 
 		return nil
 	})
-
-	j, _ = json.MarshalIndent(deployment, "", "\t")
-	println("AFTER")
-	println(string(j))
 
 	r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -33,7 +33,7 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 				return err
 			}
 			r.SetLabelsFromApplication(ctx, &serviceEntry, *application)
-			r.SetCommonAnnotations(ctx, &serviceEntry, *application)
+			util.SetCommonAnnotations(ctx, &serviceEntry)
 
 			// Avoid leaking service entry to other namespaces
 			serviceEntry.Spec.ExportTo = []string{".", "istio-system"}

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -33,7 +33,7 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 				return err
 			}
 			r.SetLabelsFromApplication(ctx, &serviceEntry, *application)
-			serviceEntry.ObjectMeta.Annotations = util.CommonAnnotations
+			r.SetCommonAnnotations(ctx, &serviceEntry, *application)
 
 			// Avoid leaking service entry to other namespaces
 			serviceEntry.Spec.ExportTo = []string{".", "istio-system"}

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	"golang.org/x/exp/slices"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -33,7 +33,7 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 				return err
 			}
 			r.SetLabelsFromApplication(ctx, &serviceEntry, *application)
-			util.SetCommonAnnotations(ctx, &serviceEntry)
+			util.SetCommonAnnotations(&serviceEntry)
 
 			// Avoid leaking service entry to other namespaces
 			serviceEntry.Spec.ExportTo = []string{".", "istio-system"}

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,7 +25,7 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 		}
 
 		r.SetLabelsFromApplication(ctx, &horizontalPodAutoscaler, *application)
-		util.SetCommonAnnotations(ctx, &horizontalPodAutoscaler)
+		util.SetCommonAnnotations(&horizontalPodAutoscaler)
 
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.APIVersion = "apps/v1"
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.Kind = "Deployment"

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	"github.com/kartverket/skiperator/pkg/util"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,7 +24,7 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 		}
 
 		r.SetLabelsFromApplication(ctx, &horizontalPodAutoscaler, *application)
-		horizontalPodAutoscaler.ObjectMeta.Annotations = util.CommonAnnotations
+		r.SetCommonAnnotations(ctx, &horizontalPodAutoscaler, *application)
 
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.APIVersion = "apps/v1"
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.Kind = "Deployment"

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,7 +25,7 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 		}
 
 		r.SetLabelsFromApplication(ctx, &horizontalPodAutoscaler, *application)
-		r.SetCommonAnnotations(ctx, &horizontalPodAutoscaler, *application)
+		util.SetCommonAnnotations(ctx, &horizontalPodAutoscaler)
 
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.APIVersion = "apps/v1"
 		horizontalPodAutoscaler.Spec.ScaleTargetRef.Kind = "Deployment"

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -35,7 +35,7 @@ func (r *ApplicationReconciler) reconcileIngressGateway(ctx context.Context, app
 			}
 
 			r.SetLabelsFromApplication(ctx, &gateway, *application)
-			r.SetCommonAnnotations(ctx, &gateway, *application)
+			util.SetCommonAnnotations(ctx, &gateway)
 
 			if util.IsInternal(hostname) {
 				gateway.Spec.Selector = map[string]string{"ingress": "internal"}

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -35,7 +35,7 @@ func (r *ApplicationReconciler) reconcileIngressGateway(ctx context.Context, app
 			}
 
 			r.SetLabelsFromApplication(ctx, &gateway, *application)
-			gateway.ObjectMeta.Annotations = util.CommonAnnotations
+			r.SetCommonAnnotations(ctx, &gateway, *application)
 
 			if util.IsInternal(hostname) {
 				gateway.Spec.Selector = map[string]string{"ingress": "internal"}

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	"golang.org/x/exp/slices"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -35,7 +35,7 @@ func (r *ApplicationReconciler) reconcileIngressGateway(ctx context.Context, app
 			}
 
 			r.SetLabelsFromApplication(ctx, &gateway, *application)
-			util.SetCommonAnnotations(ctx, &gateway)
+			util.SetCommonAnnotations(&gateway)
 
 			if util.IsInternal(hostname) {
 				gateway.Spec.Selector = map[string]string{"ingress": "internal"}

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +31,7 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 			}
 
 			r.SetLabelsFromApplication(ctx, &virtualService, *application)
-			virtualService.ObjectMeta.Annotations = util.CommonAnnotations
+			r.SetCommonAnnotations(ctx, &virtualService, *application)
 
 			gateways := make([]string, 0, len(application.Spec.Ingresses))
 			for _, hostname := range application.Spec.Ingresses {

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +32,7 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 			}
 
 			r.SetLabelsFromApplication(ctx, &virtualService, *application)
-			util.SetCommonAnnotations(ctx, &virtualService)
+			util.SetCommonAnnotations(&virtualService)
 
 			gateways := make([]string, 0, len(application.Spec.Ingresses))
 			for _, hostname := range application.Spec.Ingresses {

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	networkingv1beta1api "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 			}
 
 			r.SetLabelsFromApplication(ctx, &virtualService, *application)
-			r.SetCommonAnnotations(ctx, &virtualService, *application)
+			util.SetCommonAnnotations(ctx, &virtualService)
 
 			gateways := make([]string, 0, len(application.Spec.Ingresses))
 			for _, hostname := range application.Spec.Ingresses {

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -58,7 +58,7 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		}
 
 		r.SetLabelsFromApplication(ctx, &networkPolicy, *application)
-		networkPolicy.ObjectMeta.Annotations = util.CommonAnnotations
+		r.SetCommonAnnotations(ctx, &networkPolicy, *application)
 
 		labels := map[string]string{"app": application.Name}
 		networkPolicy.Spec.PodSelector.MatchLabels = labels

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -58,7 +58,7 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		}
 
 		r.SetLabelsFromApplication(ctx, &networkPolicy, *application)
-		r.SetCommonAnnotations(ctx, &networkPolicy, *application)
+		util.SetCommonAnnotations(ctx, &networkPolicy)
 
 		labels := map[string]string{"app": application.Name}
 		networkPolicy.Spec.PodSelector.MatchLabels = labels

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -58,7 +58,7 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		}
 
 		r.SetLabelsFromApplication(ctx, &networkPolicy, *application)
-		util.SetCommonAnnotations(ctx, &networkPolicy)
+		util.SetCommonAnnotations(&networkPolicy)
 
 		labels := map[string]string{"app": application.Name}
 		networkPolicy.Spec.PodSelector.MatchLabels = labels

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	securityv1beta1api "istio.io/api/security/v1beta1"
 	typev1beta1 "istio.io/api/type/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -26,7 +27,7 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 		}
 
 		r.SetLabelsFromApplication(ctx, &peerAuthentication, *application)
-		r.SetCommonAnnotations(ctx, &peerAuthentication, *application)
+		util.SetCommonAnnotations(ctx, &peerAuthentication)
 
 		peerAuthentication.Spec.Selector = &typev1beta1.WorkloadSelector{}
 		labels := map[string]string{"app": application.Name}

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	"github.com/kartverket/skiperator/pkg/util"
 	securityv1beta1api "istio.io/api/security/v1beta1"
 	typev1beta1 "istio.io/api/type/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -27,7 +26,7 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 		}
 
 		r.SetLabelsFromApplication(ctx, &peerAuthentication, *application)
-		peerAuthentication.ObjectMeta.Annotations = util.CommonAnnotations
+		r.SetCommonAnnotations(ctx, &peerAuthentication, *application)
 
 		peerAuthentication.Spec.Selector = &typev1beta1.WorkloadSelector{}
 		labels := map[string]string{"app": application.Name}

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	securityv1beta1api "istio.io/api/security/v1beta1"
 	typev1beta1 "istio.io/api/type/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -27,7 +27,7 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 		}
 
 		r.SetLabelsFromApplication(ctx, &peerAuthentication, *application)
-		util.SetCommonAnnotations(ctx, &peerAuthentication)
+		util.SetCommonAnnotations(&peerAuthentication)
 
 		peerAuthentication.Spec.Selector = &typev1beta1.WorkloadSelector{}
 		labels := map[string]string{"app": application.Name}

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -25,7 +26,7 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		}
 
 		r.SetLabelsFromApplication(ctx, &service, *application)
-		r.SetCommonAnnotations(ctx, &service, *application)
+		util.SetCommonAnnotations(ctx, &service)
 
 		labels := map[string]string{"app": application.Name}
 		service.Spec.Selector = labels

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -26,7 +26,7 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		}
 
 		r.SetLabelsFromApplication(ctx, &service, *application)
-		util.SetCommonAnnotations(ctx, &service)
+		util.SetCommonAnnotations(&service)
 
 		labels := map[string]string{"app": application.Name}
 		service.Spec.Selector = labels

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -26,7 +25,7 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		}
 
 		r.SetLabelsFromApplication(ctx, &service, *application)
-		service.ObjectMeta.Annotations = util.CommonAnnotations
+		r.SetCommonAnnotations(ctx, &service, *application)
 
 		labels := map[string]string{"app": application.Name}
 		service.Spec.Selector = labels

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,7 +25,7 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 		}
 
 		r.SetLabelsFromApplication(ctx, &serviceAccount, *application)
-		util.SetCommonAnnotations(ctx, &serviceAccount)
+		util.SetCommonAnnotations(&serviceAccount)
 
 		return nil
 	})

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
-	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,7 +24,7 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 		}
 
 		r.SetLabelsFromApplication(ctx, &serviceAccount, *application)
-		serviceAccount.ObjectMeta.Annotations = util.CommonAnnotations
+		r.SetCommonAnnotations(ctx, &serviceAccount, *application)
 
 		return nil
 	})

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	util "github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,7 +25,7 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 		}
 
 		r.SetLabelsFromApplication(ctx, &serviceAccount, *application)
-		r.SetCommonAnnotations(ctx, &serviceAccount, *application)
+		util.SetCommonAnnotations(ctx, &serviceAccount)
 
 		return nil
 	})

--- a/controllers/namespace/controller.go
+++ b/controllers/namespace/controller.go
@@ -3,7 +3,7 @@ package namespacecontroller
 import (
 	"context"
 
-	util "github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"context"
 	"hash/fnv"
 	"regexp"
 
@@ -62,7 +61,7 @@ func GenerateHashFromName(name string) uint64 {
 	return hash.Sum64()
 }
 
-func SetCommonAnnotations(context context.Context, object client.Object) {
+func SetCommonAnnotations(object client.Object) {
 	annotations := object.GetAnnotations()
 	if len(annotations) == 0 {
 		annotations = make(map[string]string)

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -1,11 +1,14 @@
 package util
 
 import (
+	"context"
 	"hash/fnv"
 	"regexp"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var internalPattern = regexp.MustCompile(`[^.]\.skip\.statkart\.no`)
@@ -45,7 +48,7 @@ var excludedNamespaces = []string{
 	"crossplane-system",
 	"upbound-system",
 	"instana-autotrace-webhook",
-	"fluentd", //POC
+	"fluentd",          //POC
 	"external-secrets", //POC
 }
 
@@ -57,4 +60,13 @@ func GenerateHashFromName(name string) uint64 {
 	hash := fnv.New64()
 	_, _ = hash.Write([]byte(name))
 	return hash.Sum64()
+}
+
+func SetCommonAnnotations(context context.Context, object client.Object) {
+	annotations := object.GetAnnotations()
+	if len(annotations) == 0 {
+		annotations = make(map[string]string)
+	}
+	maps.Copy(annotations, CommonAnnotations)
+	object.SetAnnotations(annotations)
 }

--- a/pkg/util/reconciler.go
+++ b/pkg/util/reconciler.go
@@ -150,3 +150,14 @@ func (r *ReconcilerBase) SetLabelsFromApplication(context context.Context, objec
 
 	r.setResourceLabelsIfApplies(context, object, app)
 }
+
+func (r *ReconcilerBase) SetCommonAnnotations(context context.Context, object client.Object, app skiperatorv1alpha1.Application) {
+	annotations := object.GetAnnotations()
+	if len(annotations) == 0 {
+		annotations = make(map[string]string)
+	}
+	maps.Copy(annotations, CommonAnnotations)
+	object.SetAnnotations(annotations)
+
+	r.setResourceLabelsIfApplies(context, object, app)
+}

--- a/pkg/util/reconciler.go
+++ b/pkg/util/reconciler.go
@@ -150,14 +150,3 @@ func (r *ReconcilerBase) SetLabelsFromApplication(context context.Context, objec
 
 	r.setResourceLabelsIfApplies(context, object, app)
 }
-
-func (r *ReconcilerBase) SetCommonAnnotations(context context.Context, object client.Object, app skiperatorv1alpha1.Application) {
-	annotations := object.GetAnnotations()
-	if len(annotations) == 0 {
-		annotations = make(map[string]string)
-	}
-	maps.Copy(annotations, CommonAnnotations)
-	object.SetAnnotations(annotations)
-
-	r.setResourceLabelsIfApplies(context, object, app)
-}


### PR DESCRIPTION
Annotations added automatically, in this case `"deployment.kubernetes.io/revision": "7"`, were overwritten by Skiperator, forcing looping reconciles.

Added a helper util for merging the current annotations with the common annotations.