### PR TITLE
Bump Go to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.20 as builder
 WORKDIR /build
 
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kartverket/skiperator
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cert-manager/cert-manager v1.11.0


### PR DESCRIPTION
We're currently using go 1.18. See the release notes for the following versions:
- [1.19](https://tip.golang.org/doc/go1.19)
- [1.20](https://tip.golang.org/doc/go1.20)

My favorite tidbits:

**Runtime**
> On Unix operating systems, Go programs that import package [os](https://tip.golang.org/pkg/os/) now automatically increase the open file limit (RLIMIT_NOFILE) to the maximum allowed value; that is, they change the soft limit to match the hard limit. This corrects artificially low limits set on some systems for compatibility with very old C programs using the [select](https://en.wikipedia.org/wiki/Select_(Unix)) system call. Go programs are not helped by that limit, and instead even simple programs like gofmt often ran out of file descriptors on such systems when processing many files in parallel. One impact of this change is that Go programs that in turn execute very old C programs in child processes may run those programs with too high a limit. This can be corrected by setting the hard limit before invoking the Go program.

**Vet**
> The vet tool now reports use of the time format 2006-02-01 (yyyy-dd-mm) with [Time.Format](https://tip.golang.org/pkg/time/#Time.Format) and [time.Parse](https://tip.golang.org/pkg/time/#Parse). This format does not appear in common date standards, but is frequently used by mistake when attempting to use the ISO 8601 date format (yyyy-mm-dd).

**Errors**
> The [fmt.Errorf](https://tip.golang.org/pkg/fmt/#Errorf) function now supports multiple occurrences of the %w format verb, which will cause it to return an error that wraps all of those error operands.

**Context**
> The new [WithCancelCause](https://tip.golang.org/pkg/context/#WithCancelCause) function provides a way to cancel a context with a given error. That error can be retrieved by calling the new [Cause](https://tip.golang.org/pkg/context/#Cause) function.

**crypto**
> crypto/rsa now uses a new, safer, constant-time backend. This causes a CPU runtime increase for decryption operations between approximately 15% (RSA-2048 on amd64) and 45% (RSA-4096 on arm64), and more on 32-bit architectures. Encryption operations are approximately 20x slower than before (but still 5-10x faster than decryption). Performance is expected to improve in future releases. Programs must not modify or manually generate the fields of [PrecomputedValues](https://tip.golang.org/pkg/crypto/rsa/#PrecomputedValues).

> crypto/tls: Parsed certificates are now shared across all clients actively using that certificate. The memory savings can be significant in programs that make many concurrent connections to a server or collection of servers sharing any part of their certificate chains.

**Core library**
> The [sync/atomic](https://tip.golang.org/pkg/sync/atomic/) package defines new atomic types [Bool](https://tip.golang.org/pkg/sync/atomic/#Bool), [Int32](https://tip.golang.org/pkg/sync/atomic/#Int32), [Int64](https://tip.golang.org/pkg/sync/atomic/#Int64), [Uint32](https://tip.golang.org/pkg/sync/atomic/#Uint32), [Uint64](https://tip.golang.org/pkg/sync/atomic/#Uint64), [Uintptr](https://tip.golang.org/pkg/sync/atomic/#Uintptr), and [Pointer](https://tip.golang.org/pkg/sync/atomic/#Pointer). These types hide the underlying values so that all accesses are forced to use the atomic APIs. [Pointer](https://tip.golang.org/pkg/sync/atomic/#Pointer) also avoids the need to convert to [unsafe.Pointer](https://tip.golang.org/pkg/unsafe/#Pointer) at call sites. [Int64](https://tip.golang.org/pkg/sync/atomic/#Int64) and [Uint64](https://tip.golang.org/pkg/sync/atomic/#Uint64) are automatically aligned to 64-bit boundaries in structs and allocated data, even on 32-bit systems.

> The new functions [Bytes](https://tip.golang.org/pkg/hash/maphash/#Bytes) and [String](https://tip.golang.org/pkg/hash/maphash/#String) provide an efficient way hash a single byte slice or string. They are equivalent to using the more general [Hash](https://tip.golang.org/pkg/hash/maphash/#Hash) with a single write, but they avoid setup overhead for small inputs.

> The new time layout constants [DateTime](https://tip.golang.org/pkg/time/#DateTime), [DateOnly](https://tip.golang.org/pkg/time/#DateOnly), and [TimeOnly](https://tip.golang.org/pkg/time/#TimeOnly) provide names for three of the most common layout strings used in a survey of public Go source code.