### PR TITLE
Add support for Pod Disruption Budgets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ $ kubens skiperator-system
 Install Istio to make sure all CRDs are available
 
 ```
-$ istioctl install
+$ kubectl create ns istio-gateways && istioctl install
 ```
 
 Cert-manager (version in link above) must be installed locally on your cluster with

--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -9,6 +9,7 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"go.uber.org/zap/zapcore"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	policyv1 "k8s.io/api/policy/v1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -44,6 +45,7 @@ func init() {
 	utilruntime.Must(securityv1beta1.AddToScheme(scheme))
 	utilruntime.Must(networkingv1beta1.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
+	utilruntime.Must(policyv1.AddToScheme(scheme))
 }
 
 func main() {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -129,6 +129,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security.istio.io
   resources:
   - authorizationpolicies

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -2,6 +2,7 @@ package applicationcontroller
 
 import (
 	"context"
+	policyv1 "k8s.io/api/policy/v1"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
@@ -30,6 +31,7 @@ import (
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=core,resources=services;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=gateways;serviceentries;virtualservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.istio.io,resources=peerauthentications;authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -58,6 +60,7 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&networkingv1beta1.VirtualService{}).
 		Owns(&securityv1beta1.PeerAuthentication{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&securityv1beta1.AuthorizationPolicy{}).
 		Watches(
@@ -108,6 +111,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		r.reconcileServiceAccount,
 		r.reconcileNetworkPolicy,
 		r.reconcileAuthorizationPolicy,
+		r.reconcilePodDisruptionBudget,
 	}
 
 	for _, fn := range controllerDuties {

--- a/controllers/application/pod_disruption_budget.go
+++ b/controllers/application/pod_disruption_budget.go
@@ -1,0 +1,55 @@
+package applicationcontroller
+
+import (
+	"context"
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/util"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *ApplicationReconciler) reconcilePodDisruptionBudget(ctx context.Context, application *skiperatorv1alpha1.Application) (reconcile.Result, error) {
+	controllerName := "PodDisruptionBudget"
+	_, _ = r.SetControllerProgressing(ctx, application, controllerName)
+
+	labels := map[string]string{"app": application.Name}
+
+	pdb := policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
+	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &pdb, func() error {
+		// Set application as owner of the PDB
+		err := ctrlutil.SetControllerReference(application, &pdb, r.GetScheme())
+		if err != nil {
+			_, _ = r.SetControllerError(ctx, application, controllerName, err)
+			return err
+		}
+
+		r.SetLabelsFromApplication(ctx, &pdb, *application)
+		util.SetCommonAnnotations(&pdb)
+
+		pdb.Spec = policyv1.PodDisruptionBudgetSpec{
+			Selector:     &metav1.LabelSelector{MatchLabels: labels},
+			MinAvailable: determineMinAvailable(application.Spec.Replicas.Min),
+		}
+
+		return nil
+	})
+
+	_, _ = r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+
+	return reconcile.Result{}, err
+}
+
+func determineMinAvailable(replicasAvailable uint) *intstr.IntOrString {
+	var value intstr.IntOrString
+
+	if replicasAvailable > 1 {
+		value = intstr.FromString("50%")
+	} else {
+		intstr.FromInt(0)
+	}
+
+	return &value
+}

--- a/tests/pdb/00-application.yaml
+++ b/tests/pdb/00-application.yaml
@@ -1,0 +1,29 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: no-disruption-1
+spec:
+  image: image
+  port: 8080
+  replicas:
+    min: 2
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: no-disruption-2
+spec:
+  image: image
+  port: 8080
+  replicas:
+    min: 10
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: yes-disruption
+spec:
+  image: image
+  port: 8080
+  replicas:
+    min: 1

--- a/tests/pdb/00-assert.yaml
+++ b/tests/pdb/00-assert.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: no-disruption-1
+spec:
+  minAvailable: 50%
+  selector:
+    matchLabels:
+      app: no-disruption-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: no-disruption-2
+spec:
+  minAvailable: 50%
+  selector:
+    matchLabels:
+      app: no-disruption-2
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: yes-disruption
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: yes-disruption

--- a/tests/pdb/01-delete-application.yaml
+++ b/tests/pdb/01-delete-application.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: no-disruption-1
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: no-disruption-2
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: yes-disruption


### PR DESCRIPTION
In order to reduce possible disruptions and increase availability, support for PDBs is introduced in this PR. The logic is pretty simple:

If number of `minReplicas` is greater than 1, specify a PDB with `minAvailable` set to `50%`, otherwise `minAvailable` is set to `0`.