### PR TITLE
[SKIP-616] Move SeccompProfile from Container to Pod level

### DIFF
--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -78,12 +78,12 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
 		deployment.Spec.Template.Spec.SecurityContext.SupplementalGroups = []int64{uid}
 		deployment.Spec.Template.Spec.SecurityContext.FSGroup = &uid
+		deployment.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
+		deployment.Spec.Template.Spec.SecurityContext.SeccompProfile.Type = "RuntimeDefault"
 
 		yes := true
 		no := false
 		container.SecurityContext = &corev1.SecurityContext{}
-		container.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
-		container.SecurityContext.SeccompProfile.Type = "RuntimeDefault"
 		container.SecurityContext.Privileged = &no
 		container.SecurityContext.AllowPrivilegeEscalation = &no
 		container.SecurityContext.ReadOnlyRootFilesystem = &yes

--- a/tests/minimal/00-assert.yaml
+++ b/tests/minimal/00-assert.yaml
@@ -34,8 +34,6 @@ spec:
             readOnlyRootFilesystem: true
             runAsGroup: 150
             runAsUser: 150
-            seccompProfile:
-              type: RuntimeDefault
           volumeMounts:
             - mountPath: /tmp
               name: tmp
@@ -45,6 +43,8 @@ spec:
         fsGroup: 150
         supplementalGroups:
           - 150
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: minimal
       volumes:
         - emptyDir: {}


### PR DESCRIPTION
Suggested fix to allow for using [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission) in enforce mode alongside Istio sidecars.

Moves SeccompProfile from container level to pod level so it applies to the istio sidecars as well as the application container, which should make PSA happy.

See: https://github.com/istio/istio/issues/35894