### PR TITLE
SKIP-1052 Validate Ingresses and Redirect https default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ spec:
   # Most workloads should not have to specify this field. If you think you
   # do, please consult with SKIP beforehand.
   priority: medium
-  # An optional list of extra port to expose on a pod level basis, 
+  # An optional list of extra port to expose on a pod level basis,
   # for example so Instana or other APM tools can reach it
   additionalPorts:
     - name: metrics-port
@@ -56,6 +56,7 @@ spec:
   # (also known as pretty hostnames) requires additional DNS setup.
   # The below hostnames will also have TLS certificates issued and be reachable on both
   # HTTP and HTTPS.
+  # Ingresses must be lowercase, contain no spaces, and be non-empty
   ingresses:
     - testapp.dev.skip.statkart.no
   # Configuration used to automatically scale the deployment based on load

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ spec:
   # (also known as pretty hostnames) requires additional DNS setup.
   # The below hostnames will also have TLS certificates issued and be reachable on both
   # HTTP and HTTPS.
-  # Ingresses must be lowercase, contain no spaces, and be non-empty
+  # Ingress must be lower case, contain no spaces, be a non-empty string, and have a hostname/domain separated by a period
   ingresses:
     - testapp.dev.skip.statkart.no
   # Configuration used to automatically scale the deployment based on load

--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -72,8 +72,8 @@ type ApplicationSpec struct {
 	Ingresses []string `json:"ingresses,omitempty"`
 
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default=true
-	RedirectToHTTPS bool `json:"redirectToHTTPS,omitempty"`
+	//+kubebuilder:default:=true
+	RedirectToHTTPS *bool `json:"redirectToHTTPS,omitempty"`
 
 	//+kubebuilder:validation:Optional
 	AccessPolicy AccessPolicy `json:"accessPolicy,omitempty"`

--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -66,11 +66,14 @@ type ApplicationSpec struct {
 	//+kubebuilder:validation:Optional
 	Startup *Probe `json:"startup,omitempty"`
 
-	// Ingresses must be lowercase, contain no spaces, and be non-empty
+	// Ingresses must be lower case, contain no spaces, be a non-empty string, and have a hostname/domain separated by a period
 	//
 	//+kubebuilder:validation:Optional
 	Ingresses []string `json:"ingresses,omitempty"`
 
+	// Controls whether or not the application will automatically redirect all HTTP calls to HTTPS via the istio VirtualService.
+	// This redirect does not happen on the route /.well-known/acme-challenge/, as the ACME challenge can only be done on port 80.
+	//
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=true
 	RedirectToHTTPS *bool `json:"redirectToHTTPS,omitempty"`

--- a/api/v1alpha1/application.go
+++ b/api/v1alpha1/application.go
@@ -66,11 +66,13 @@ type ApplicationSpec struct {
 	//+kubebuilder:validation:Optional
 	Startup *Probe `json:"startup,omitempty"`
 
+	// Ingresses must be lowercase, contain no spaces, and be non-empty
+	//
 	//+kubebuilder:validation:Optional
 	Ingresses []string `json:"ingresses,omitempty"`
 
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default=false
+	//+kubebuilder:default=true
 	RedirectToHTTPS bool `json:"redirectToHTTPS,omitempty"`
 
 	//+kubebuilder:validation:Optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -139,6 +139,11 @@ func (in *ApplicationSpec) DeepCopyInto(out *ApplicationSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RedirectToHTTPS != nil {
+		in, out := &in.RedirectToHTTPS, &out.RedirectToHTTPS
+		*out = new(bool)
+		**out = **in
+	}
 	in.AccessPolicy.DeepCopyInto(&out.AccessPolicy)
 	if in.GCP != nil {
 		in, out := &in.GCP, &out.GCP

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -274,6 +274,8 @@ spec:
               image:
                 type: string
               ingresses:
+                description: Ingresses must be lowercase, contain no spaces, and be
+                  non-empty
                 items:
                   type: string
                 type: array
@@ -323,7 +325,7 @@ spec:
                 - port
                 type: object
               redirectToHTTPS:
-                default: false
+                default: true
                 type: boolean
               replicas:
                 properties:

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -241,7 +241,7 @@ func ValidateIngresses(application *skiperatorv1alpha1.Application) error {
 	matchExpression, _ := regexp.Compile(`^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$`)
 	for _, ingress := range application.Spec.Ingresses {
 		if !matchExpression.MatchString(ingress) {
-			errMessage := fmt.Sprintf("ingress with value '%s' was not valid. ingress must be lower case, contain no spaces, and be a non-empty string", ingress)
+			errMessage := fmt.Sprintf("ingress with value '%s' was not valid. ingress must be lower case, contain no spaces, be a non-empty string, and have a hostname/domain separated by a period", ingress)
 			return errors.NewInvalid(application.GroupVersionKind().GroupKind(), application.Name, field.ErrorList{
 				field.Invalid(field.NewPath("application").Child("spec").Child("ingresses"), application.Spec.Ingresses, errMessage),
 			})

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -3,7 +3,7 @@ package applicationcontroller
 import (
 	"context"
 	"fmt"
-	"strings"
+	"regexp"
 
 	policyv1 "k8s.io/api/policy/v1"
 
@@ -238,8 +238,9 @@ func (r *ApplicationReconciler) validateApplicationSpec(application *skiperatorv
 }
 
 func ValidateIngresses(application *skiperatorv1alpha1.Application) error {
+	matchExpression, _ := regexp.Compile(`^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$`)
 	for _, ingress := range application.Spec.Ingresses {
-		if ingress == "" || util.HasUpperCaseLetter(ingress) || strings.Contains(ingress, " ") {
+		if !matchExpression.MatchString(ingress) {
 			errMessage := fmt.Sprintf("ingress with value '%s' was not valid. ingress must be lower case, contain no spaces, and be a non-empty string", ingress)
 			return errors.NewInvalid(application.GroupVersionKind().GroupKind(), application.Name, field.ErrorList{
 				field.Invalid(field.NewPath("application").Child("spec").Child("ingresses"), application.Spec.Ingresses, errMessage),

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -94,16 +94,6 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		return reconcile.Result{}, err
 	}
 
-	err = r.validateApplicationSpec(application)
-	if err != nil {
-		r.GetRecorder().Eventf(
-			application,
-			corev1.EventTypeWarning, "InvalidApplication",
-			"Application was not valid, error: %s", err.Error(),
-		)
-		return reconcile.Result{}, err
-	}
-
 	r.GetRecorder().Eventf(
 		application,
 		corev1.EventTypeNormal, "ReconcileStart",
@@ -123,6 +113,16 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 				return ctrl.Result{}, err
 			}
 		}
+	}
+
+	err = r.validateApplicationSpec(application)
+	if err != nil {
+		r.GetRecorder().Eventf(
+			application,
+			corev1.EventTypeWarning, "InvalidApplication",
+			"Application was not valid, error: %s", err.Error(),
+		)
+		return reconcile.Result{}, err
 	}
 
 	controllerDuties := []func(context.Context, *skiperatorv1alpha1.Application) (reconcile.Result, error){

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -120,7 +120,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		r.GetRecorder().Eventf(
 			application,
 			corev1.EventTypeWarning, "InvalidApplication",
-			"Application was not valid, error: %s", err.Error(),
+			"Application failed validation and was rejected, error: %s", err.Error(),
 		)
 		return reconcile.Result{}, err
 	}

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -42,7 +42,7 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 				Http:     []*networkingv1beta1api.HTTPRoute{},
 			}
 
-			if application.Spec.RedirectToHTTPS {
+			if application.Spec.RedirectToHTTPS != nil && *application.Spec.RedirectToHTTPS {
 				virtualService.Spec.Http = append(virtualService.Spec.Http, &networkingv1beta1api.HTTPRoute{
 					Name: "redirect-to-https",
 					Match: []*networkingv1beta1api.HTTPMatchRequest{

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"regexp"
+	"unicode"
 
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
@@ -70,4 +71,16 @@ func PointTo[T any](x T) *T {
 
 func GetApplicationSelector(applicationName string) map[string]string {
 	return map[string]string{"app": applicationName}
+}
+
+func HasUpperCaseLetter(word string) bool {
+	hasUpper := false
+	for _, letter := range word {
+		if unicode.IsUpper(letter) {
+			hasUpper = true
+			break
+		}
+	}
+
+	return hasUpper
 }

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -74,13 +74,11 @@ func GetApplicationSelector(applicationName string) map[string]string {
 }
 
 func HasUpperCaseLetter(word string) bool {
-	hasUpper := false
 	for _, letter := range word {
 		if unicode.IsUpper(letter) {
-			hasUpper = true
-			break
+			return true
 		}
 	}
 
-	return hasUpper
+	return false
 }

--- a/tests/validation-ingresses/00-application.yaml
+++ b/tests/validation-ingresses/00-application.yaml
@@ -27,3 +27,13 @@ spec:
   port: 8080
   ingresses:
     - ""
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: ingresses-no-domain
+spec:
+  image: image
+  port: 8080
+  ingresses:
+    - test

--- a/tests/validation-ingresses/00-application.yaml
+++ b/tests/validation-ingresses/00-application.yaml
@@ -1,0 +1,29 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: ingresses-space
+spec:
+  image: image
+  port: 8080
+  ingresses:
+    - example com
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: ingresses-capital
+spec:
+  image: image
+  port: 8080
+  ingresses:
+    - TEST.com
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: ingresses-empty
+spec:
+  image: image
+  port: 8080
+  ingresses:
+    - ""

--- a/tests/validation-ingresses/00-assert.yaml
+++ b/tests/validation-ingresses/00-assert.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Event
+reason: InvalidApplication
+source:
+  component: application-controller
+involvedObject:
+  apiVersion: skiperator.kartverket.no/v1alpha1
+  kind: Application
+  name: ingresses-space
+---
+apiVersion: v1
+kind: Event
+reason: InvalidApplication
+source:
+  component: application-controller
+involvedObject:
+  apiVersion: skiperator.kartverket.no/v1alpha1
+  kind: Application
+  name: ingresses-empty
+---
+apiVersion: v1
+kind: Event
+reason: InvalidApplication
+source:
+  component: application-controller
+involvedObject:
+  apiVersion: skiperator.kartverket.no/v1alpha1
+  kind: Application
+  name: ingresses-capital

--- a/tests/validation-ingresses/00-assert.yaml
+++ b/tests/validation-ingresses/00-assert.yaml
@@ -27,3 +27,13 @@ involvedObject:
   apiVersion: skiperator.kartverket.no/v1alpha1
   kind: Application
   name: ingresses-capital
+---
+apiVersion: v1
+kind: Event
+reason: InvalidApplication
+source:
+  component: application-controller
+involvedObject:
+  apiVersion: skiperator.kartverket.no/v1alpha1
+  kind: Application
+  name: ingresses-no-domain

--- a/tests/validation-ingresses/01-delete-application.yaml
+++ b/tests/validation-ingresses/01-delete-application.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: ingresses-capital
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: ingresses-empty
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: ingresses-space

--- a/tests/validation-ingresses/01-delete-application.yaml
+++ b/tests/validation-ingresses/01-delete-application.yaml
@@ -10,3 +10,6 @@ delete:
   - apiVersion: skiperator.kartverket.no/v1alpha1
     kind: Application
     name: ingresses-space
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: ingresses-no-domain


### PR DESCRIPTION
Created a wrapper for Validation Functions and a PoC for how to validate different resources with proper errors. Not sure if this is how we should handle validation long term, but it seems to suffice now.

Ingresses can not be empty, contains spaces or uppercase letters.

Result of a malformed ingress here:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/61270418/236470329-ce1f8bdc-577e-41ee-a40a-9c35cefbfd57.png">

RedirectToHTTPS defaults to true. 