### PR TITLE
Add typemeta to deployment init

### DIFF
--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -24,7 +24,16 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 	controllerName := "Deployment"
 	r.SetControllerProgressing(ctx, application, controllerName)
 
-	deployment := appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
+	deployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: application.Namespace,
+			Name:      application.Name,
+		},
+	}
 
 	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &deployment, func() error {
 		// Set application as owner of the deployment


### PR DESCRIPTION
If typemeta is not defined on deployment struct init, resource labels are not added due to the source object not having its typemeta set before the actual creation of the resource.

This caused gatekeeper to not allow replicalimits to be less than 2 even if the resource label for excluding this rule was added.