### PR TITLE
Add app label to service

### DIFF
--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -28,6 +28,11 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		r.SetLabelsFromApplication(ctx, &service, *application)
 		util.SetCommonAnnotations(&service)
 
+		// ServiceMonitor requires labels to be set on service to select it
+		labels := service.GetLabels()
+		labels["app"] = application.Name
+		service.SetLabels(labels)
+
 		service.Spec = corev1.ServiceSpec{
 			Selector: util.GetApplicationSelector(application.Name),
 			Type:     corev1.ServiceTypeClusterIP,


### PR DESCRIPTION
When using ServiceMonitors, it creates a selector that selects a service. This currently uses the `app` label, which is not present on the service (in fact there are no labels on it at all). This PR adds labels to the service.