### PR TITLE
Allow port number or name in probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ spec:
   liveness:
     # The path to access on the HTTP server
     path: /healthz
-    # Number of the port to access on the container
+    # Number or name of the port to access on the container
     port: 8080
     # Minimum consecutive failures for the probe to be considered failed after
     # having succeeded. Defaults to 3. Minimum value is 1

--- a/api/v1alpha1/podtypes/probe.go
+++ b/api/v1alpha1/podtypes/probe.go
@@ -1,5 +1,7 @@
 package podtypes
 
+import "k8s.io/apimachinery/pkg/util/intstr"
+
 type Probe struct {
 	//+kubebuilder:default=0
 	//+kubebuilder:validation:Optional
@@ -17,7 +19,7 @@ type Probe struct {
 	//+kubebuilder:validation:Optional
 	FailureThreshold int32 `json:"failureThreshold,omitempty"`
 	//+kubebuilder:validation:Required
-	Port uint16 `json:"port"`
+	Port intstr.IntOrString `json:"port"`
 	//+kubebuilder:validation:Required
 	Path string `json:"path"`
 }

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -330,7 +330,10 @@ spec:
                     format: int32
                     type: integer
                   port:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
                   successThreshold:
                     default: 1
                     format: int32
@@ -392,7 +395,10 @@ spec:
                     format: int32
                     type: integer
                   port:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
                   successThreshold:
                     default: 1
                     format: int32
@@ -470,7 +476,10 @@ spec:
                     format: int32
                     type: integer
                   port:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
                   successThreshold:
                     default: 1
                     format: int32

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -239,7 +239,7 @@ func getProbe(appProbe *podtypes.Probe) *corev1.Probe {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   appProbe.Path,
-					Port:   intstr.FromInt(int(appProbe.Port)),
+					Port:   appProbe.Port,
 					Scheme: corev1.URISchemeHTTP,
 				},
 			},


### PR DESCRIPTION
Removing a self-imposed limitation.

See the updated [HTTPGetAction in the v1 k8n spec](https://github.com/kubernetes/api/blob/master/core/v1/types.go)