### PR TITLE
Istio+Prometheus: Resolve port name to port number

### DIFF
--- a/tests/service-monitor/04-assert.yaml
+++ b/tests/service-monitor/04-assert.yaml
@@ -14,7 +14,7 @@ spec:
         prometheus.io/scrape: 'true'
         # Needed for Prometheus metrics merging
         prometheus.io/path: /metrics
-        prometheus.io/port: metrics
+        prometheus.io/port: "8181"
     spec:
       containers:
         - name: some-monitored-app-1


### PR DESCRIPTION
This enables referring to port name when enabling prometheus.

```yaml
apiVersion: skiperator.kartverket.no/v1alpha1
kind: Application
metadata:
  name: my-app
  namespace: my-ns
spec:
  image: "evenh/prom-demo:latest"
  port: 5000
  priority: low
  additionalPorts:
    - name: management
      port: 5100
      protocol: TCP
  liveness:
    path: /actuator/health
    port: management
  prometheus:
    path: /actuator/prometheus
    port: management # This will now be resolved to an actual port number, used for instructing Istio where to scrape
```