### PR TITLE
[SKIP-705] Extract resource generation to own packages

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -396,11 +396,3 @@ func (a *Application) GroupKindFromControllerResource(controllerResource string)
 		return metav1.GroupKind{}, false
 	}
 }
-
-func (a *Application) IstioEnabled() bool {
-	if a.Spec.Prometheus == nil {
-		return false
-	}
-
-	return *a.Spec.Prometheus.IstioEnabled
-}

--- a/api/v1alpha1/podtypes/access_policy.go
+++ b/api/v1alpha1/podtypes/access_policy.go
@@ -10,7 +10,6 @@ type AccessPolicy struct {
 
 // +kubebuilder:object:generate=true
 type InboundPolicy struct {
-	//+kubebuilder:validation:Optional
 	Rules []InternalRule `json:"rules"`
 }
 

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -53,6 +53,8 @@ spec:
                           - application
                           type: object
                         type: array
+                    required:
+                    - rules
                     type: object
                   outbound:
                     properties:

--- a/controllers/application/authorization_policy.go
+++ b/controllers/application/authorization_policy.go
@@ -99,7 +99,7 @@ func getDefaultDenyPolicy(application *skiperatorv1alpha1.Application, denyPaths
 				},
 			},
 			Selector: &typev1beta1.WorkloadSelector{
-				MatchLabels: util.GetApplicationSelector(application.Name),
+				MatchLabels: util.GetPodAppSelector(application.Name),
 			},
 		},
 	}

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -72,7 +72,6 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&securityv1beta1.AuthorizationPolicy{}).
 		Owns(&pov1.ServiceMonitor{}).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(r.SkiperatorOwnedCertRequests)).
-		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.NetworkPoliciesFromService)).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -180,8 +180,6 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 			&deploymentDefinition.Labels,
 		})
 
-		util.GetObjectDiff(deployment.Spec, deploymentDefinition.Spec)
-
 		if deploymentHash != deploymentDefinitionHash {
 			patch := client.MergeFrom(deployment.DeepCopy())
 			err = r.GetClient().Patch(ctx, &deploymentDefinition, patch)

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -180,6 +180,8 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 			&deploymentDefinition.Labels,
 		})
 
+		util.GetObjectDiff(deployment.Spec, deploymentDefinition.Spec)
+
 		if deploymentHash != deploymentDefinitionHash {
 			patch := client.MergeFrom(deployment.DeepCopy())
 			err = r.GetClient().Patch(ctx, &deploymentDefinition, patch)
@@ -311,7 +313,8 @@ func getContainerVolumeMountsAndPodVolumes(application *skiperatorv1alpha1.Appli
 				Name: file.Secret,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: file.Secret,
+						SecretName:  file.Secret,
+						DefaultMode: util.PointTo(int32(420)),
 					},
 				},
 			}

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -22,15 +22,17 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		return reconcile.Result{}, err
 	}
 
-	netpolSpec := networking.CreateNetPolSpec(networking.NetPolOpts{
-		AccessPolicy:     application.Spec.AccessPolicy,
-		Ingresses:        &application.Spec.Ingresses,
-		Port:             &application.Spec.Port,
-		Namespace:        application.Namespace,
-		Name:             application.Name,
-		RelatedServices:  &egressServices,
-		PrometheusConfig: application.Spec.Prometheus,
-	})
+	netpolSpec := networking.CreateNetPolSpec(
+		networking.NetPolOpts{
+			AccessPolicy:     application.Spec.AccessPolicy,
+			Ingresses:        &application.Spec.Ingresses,
+			Port:             &application.Spec.Port,
+			Namespace:        application.Namespace,
+			Name:             application.Name,
+			RelatedServices:  &egressServices,
+			PrometheusConfig: application.Spec.Prometheus,
+		},
+	)
 
 	if netpolSpec == nil {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -2,61 +2,43 @@ package applicationcontroller
 
 import (
 	"context"
+	"github.com/kartverket/skiperator/pkg/resourcegenerator/networking"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/util"
-	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-const (
-	GrafanaAgentName      = "grafana-agent"
-	GrafanaAgentNamespace = GrafanaAgentName
-)
-
-// This is a bit hacky, but seems like best solution
-func (r *ApplicationReconciler) NetworkPoliciesFromService(ctx context.Context, obj client.Object) []reconcile.Request {
-	svc := obj.(*corev1.Service)
-
-	applications := &skiperatorv1alpha1.ApplicationList{}
-	err := r.GetClient().List(ctx, applications)
-	if err != nil {
-		return nil
-	}
-
-	requests := make([]reconcile.Request, 0, len(applications.Items))
-	for _, application := range applications.Items {
-		if application.Spec.AccessPolicy == nil {
-			continue
-		}
-		for _, rule := range application.Spec.AccessPolicy.Outbound.Rules {
-			if rule.Namespace == svc.Namespace && rule.Application == svc.Name {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: application.Namespace,
-						Name:      application.Name,
-					},
-				})
-				break
-			}
-		}
-	}
-	return requests
-}
 
 func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, application *skiperatorv1alpha1.Application) (reconcile.Result, error) {
 	controllerName := "NetworkPolicy"
 	r.SetControllerProgressing(ctx, application, controllerName)
 
+	egressServices, err := r.GetEgressServices(ctx, application, application.Spec.AccessPolicy)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
+	netpolSpec := networking.CreateNetPolSpec(networking.NetPolOpts{
+		AccessPolicy:     application.Spec.AccessPolicy,
+		Ingresses:        &application.Spec.Ingresses,
+		Port:             &application.Spec.Port,
+		Namespace:        application.Namespace,
+		Name:             application.Name,
+		RelatedServices:  &egressServices,
+		PrometheusConfig: application.Spec.Prometheus,
+	})
+
+	if netpolSpec == nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
 	networkPolicy := networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
-	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &networkPolicy, func() error {
+	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &networkPolicy, func() error {
 		// Set application as owner of the network policy
 		err := ctrlutil.SetControllerReference(application, &networkPolicy, r.GetScheme())
 		if err != nil {
@@ -67,23 +49,7 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		r.SetLabelsFromApplication(ctx, &networkPolicy, *application)
 		util.SetCommonAnnotations(&networkPolicy)
 
-		egressRules, err := r.getEgressRules(application, ctx)
-		if err != nil {
-			r.SetControllerError(ctx, application, controllerName, err)
-			return err
-		}
-
-		networkPolicy.Spec = networkingv1.NetworkPolicySpec{
-			PolicyTypes: []networkingv1.PolicyType{
-				networkingv1.PolicyTypeIngress,
-				networkingv1.PolicyTypeEgress,
-			},
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: util.GetApplicationSelector(application.Name),
-			},
-			Ingress: getIngressRules(application),
-			Egress:  egressRules,
-		}
+		networkPolicy.Spec = *netpolSpec
 
 		return nil
 	})
@@ -91,194 +57,4 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 	r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 
 	return reconcile.Result{}, err
-}
-
-func (r ApplicationReconciler) getEgressRules(application *skiperatorv1alpha1.Application, ctx context.Context) ([]networkingv1.NetworkPolicyEgressRule, error) {
-	egressRules := []networkingv1.NetworkPolicyEgressRule{}
-
-	if application.Spec.AccessPolicy == nil {
-		return egressRules, nil
-	}
-	// Egress rules for internal peers
-	for _, outboundRule := range application.Spec.AccessPolicy.Outbound.Rules {
-		if outboundRule.Namespace == "" {
-			outboundRule.Namespace = application.Namespace
-		}
-
-		service := corev1.Service{}
-		err := r.GetClient().Get(ctx, types.NamespacedName{Namespace: outboundRule.Namespace, Name: outboundRule.Application}, &service)
-		if errors.IsNotFound(err) {
-			r.GetRecorder().Eventf(
-				application,
-				corev1.EventTypeWarning, "Missing",
-				"Cannot find application named %s in namespace %s. Egress rule will not be added.",
-				outboundRule.Application, outboundRule.Namespace,
-			)
-			continue
-		} else if err != nil {
-			return egressRules, err
-		}
-
-		servicePorts := []networkingv1.NetworkPolicyPort{}
-		for _, port := range service.Spec.Ports {
-			servicePorts = append(servicePorts, networkingv1.NetworkPolicyPort{
-				Port: util.PointTo(intstr.FromInt(int(port.Port))),
-			})
-		}
-
-		egressRuleForOutboundRule := networkingv1.NetworkPolicyEgressRule{
-			Ports: servicePorts,
-			To: []networkingv1.NetworkPolicyPeer{
-				{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: service.Spec.Selector,
-					},
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"kubernetes.io/metadata.name": outboundRule.Namespace},
-					},
-				},
-			},
-		}
-
-		egressRules = append(egressRules, egressRuleForOutboundRule)
-	}
-
-	return egressRules, nil
-}
-
-func getIngressRules(application *skiperatorv1alpha1.Application) []networkingv1.NetworkPolicyIngressRule {
-	ingressRules := []networkingv1.NetworkPolicyIngressRule{}
-
-	if len(application.Spec.Ingresses) > 0 {
-		if hasInternalIngress(application.Spec.Ingresses) {
-			ingressRules = append(ingressRules, getGatewayIngressRule(*application, true))
-		}
-
-		if hasExternalIngress(application.Spec.Ingresses) {
-			ingressRules = append(ingressRules, getGatewayIngressRule(*application, false))
-		}
-	}
-
-	// If Prometheus metrics are exposed, allow grafana-agent to scrape
-	if application.Spec.Prometheus != nil {
-		promScrapeRule := networkingv1.NetworkPolicyIngressRule{
-			From: []networkingv1.NetworkPolicyPeer{
-				{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"kubernetes.io/metadata.name": GrafanaAgentNamespace},
-					},
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app.kubernetes.io/instance": GrafanaAgentName,
-							"app.kubernetes.io/name":     GrafanaAgentName,
-						},
-					},
-				},
-			},
-			Ports: []networkingv1.NetworkPolicyPort{
-				{
-					Port: determinePrometheusScrapePort(application),
-				},
-			},
-		}
-
-		ingressRules = append(ingressRules, promScrapeRule)
-	}
-
-	if application.Spec.AccessPolicy == nil {
-		return ingressRules
-	}
-
-	if len(application.Spec.AccessPolicy.Inbound.Rules) > 0 {
-		inboundTrafficIngressRule := networkingv1.NetworkPolicyIngressRule{
-			From: getInboundPolicyPeers(application),
-			Ports: []networkingv1.NetworkPolicyPort{
-				{
-					Port: util.PointTo(intstr.FromInt(application.Spec.Port)),
-				},
-			},
-		}
-
-		ingressRules = append(ingressRules, inboundTrafficIngressRule)
-	}
-
-	return ingressRules
-}
-
-func determinePrometheusScrapePort(application *skiperatorv1alpha1.Application) *intstr.IntOrString {
-	if application.IstioEnabled() {
-		return util.PointTo(IstioMetricsPortName)
-	}
-	return util.PointTo(application.Spec.Prometheus.Port)
-}
-
-func getInboundPolicyPeers(application *skiperatorv1alpha1.Application) []networkingv1.NetworkPolicyPeer {
-	policyPeers := []networkingv1.NetworkPolicyPeer{}
-
-	for _, inboundRule := range application.Spec.AccessPolicy.Inbound.Rules {
-		if inboundRule.Namespace == "" {
-			inboundRule.Namespace = application.Namespace
-		}
-
-		policyPeers = append(policyPeers, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"kubernetes.io/metadata.name": inboundRule.Namespace},
-			},
-			PodSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": inboundRule.Application},
-			},
-		})
-	}
-
-	return policyPeers
-}
-
-func hasExternalIngress(applicationIngresses []string) bool {
-	for _, hostname := range applicationIngresses {
-		if !util.IsInternal(hostname) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func hasInternalIngress(applicationIngresses []string) bool {
-	for _, hostname := range applicationIngresses {
-		if util.IsInternal(hostname) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func getGatewayIngressRule(application skiperatorv1alpha1.Application, isInternal bool) networkingv1.NetworkPolicyIngressRule {
-	ingressRule := networkingv1.NetworkPolicyIngressRule{
-		From: []networkingv1.NetworkPolicyPeer{
-			{
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "istio-gateways"},
-				},
-				PodSelector: &metav1.LabelSelector{
-					MatchLabels: getIngressGatewayLabel(isInternal),
-				},
-			},
-		},
-		Ports: []networkingv1.NetworkPolicyPort{
-			{
-				Port: util.PointTo(intstr.FromInt(application.Spec.Port)),
-			},
-		},
-	}
-
-	return ingressRule
-}
-
-func getIngressGatewayLabel(isInternal bool) map[string]string {
-	if isInternal {
-		return map[string]string{"app": "istio-ingress-internal"}
-	} else {
-		return map[string]string{"app": "istio-ingress-external"}
-	}
 }

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -28,7 +28,7 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 
 		peerAuthentication.Spec = securityv1beta1api.PeerAuthentication{
 			Selector: &typev1beta1.WorkloadSelector{
-				MatchLabels: util.GetApplicationSelector(application.Name),
+				MatchLabels: util.GetPodAppSelector(application.Name),
 			},
 			Mtls: &securityv1beta1api.PeerAuthentication_MutualTLS{
 				Mode: securityv1beta1api.PeerAuthentication_MutualTLS_STRICT,

--- a/controllers/application/pod_disruption_budget.go
+++ b/controllers/application/pod_disruption_budget.go
@@ -32,7 +32,7 @@ func (r *ApplicationReconciler) reconcilePodDisruptionBudget(ctx context.Context
 
 			pdb.Spec = policyv1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: util.GetApplicationSelector(application.Name),
+					MatchLabels: util.GetPodAppSelector(application.Name),
 				},
 				MinAvailable: determineMinAvailable(application.Spec.Replicas.Min),
 			}

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -3,6 +3,7 @@ package applicationcontroller
 import (
 	"context"
 	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
+	"github.com/kartverket/skiperator/pkg/resourcegenerator/networking"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/util"
@@ -14,10 +15,10 @@ import (
 )
 
 var defaultPrometheusPort = corev1.ServicePort{
-	Name:       IstioMetricsPortName.StrVal,
+	Name:       util.IstioMetricsPortName.StrVal,
 	Protocol:   corev1.ProtocolTCP,
-	Port:       IstioMetricsPortNumber.IntVal,
-	TargetPort: IstioMetricsPortNumber,
+	Port:       util.IstioMetricsPortNumber.IntVal,
+	TargetPort: util.IstioMetricsPortNumber,
 }
 
 func (r *ApplicationReconciler) reconcileService(ctx context.Context, application *skiperatorv1alpha1.Application) (reconcile.Result, error) {
@@ -45,12 +46,12 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 		service.SetLabels(labels)
 
 		ports := append(getAdditionalPorts(application.Spec.AdditionalPorts), getServicePort(application.Spec.Port))
-		if application.IstioEnabled() {
+		if networking.IstioEnabled(application.Spec.Prometheus) {
 			ports = append(ports, defaultPrometheusPort)
 		}
 
 		service.Spec = corev1.ServiceSpec{
-			Selector: util.GetApplicationSelector(application.Name),
+			Selector: util.GetPodAppSelector(application.Name),
 			Type:     corev1.ServiceTypeClusterIP,
 			Ports:    ports,
 		}

--- a/controllers/application/service_monitor.go
+++ b/controllers/application/service_monitor.go
@@ -6,16 +6,9 @@ import (
 	"github.com/kartverket/skiperator/pkg/util"
 	pov1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-)
-
-var (
-	IstioMetricsPortNumber = intstr.FromInt(15020)
-	IstioMetricsPortName   = intstr.FromString("istio-metrics")
-	IstioMetricsPath       = "/stats/prometheus"
 )
 
 func (r *ApplicationReconciler) reconcileServiceMonitor(ctx context.Context, application *skiperatorv1alpha1.Application) (reconcile.Result, error) {
@@ -57,7 +50,7 @@ func (r *ApplicationReconciler) reconcileServiceMonitor(ctx context.Context, app
 
 		serviceMonitor.Spec = pov1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
-				MatchLabels: util.GetApplicationSelector(application.Name),
+				MatchLabels: util.GetPodAppSelector(application.Name),
 			},
 			NamespaceSelector: pov1.NamespaceSelector{
 				MatchNames: []string{application.Namespace},
@@ -75,7 +68,7 @@ func (r *ApplicationReconciler) reconcileServiceMonitor(ctx context.Context, app
 
 func determineEndpoint(application *skiperatorv1alpha1.Application) []pov1.Endpoint {
 	ep := pov1.Endpoint{
-		Path: IstioMetricsPath, TargetPort: &IstioMetricsPortName,
+		Path: util.IstioMetricsPath, TargetPort: &util.IstioMetricsPortName,
 	}
 
 	if *application.Spec.Prometheus.IstioEnabled {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/kudobuilder/kuttl v0.15.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.66.0
+	github.com/r3labs/diff/v3 v3.0.1
 	go.etcd.io/etcd/server/v3 v3.5.9
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983
@@ -136,6 +137,8 @@ require (
 	github.com/thoas/go-funk v0.9.2 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -396,6 +396,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
+github.com/r3labs/diff/v3 v3.0.1 h1:CBKqf3XmNRHXKmdU7mZP1w7TV0pDyVCis1AUHtA4Xtg=
+github.com/r3labs/diff/v3 v3.0.1/go.mod h1:f1S9bourRbiM66NskseyUdo0fTmEE0qKrikYJX63dgo=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -424,6 +426,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -436,6 +439,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/pkg/resourcegenerator/core/pod.go
+++ b/pkg/resourcegenerator/core/pod.go
@@ -1,0 +1,170 @@
+package core
+
+import (
+	"fmt"
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
+	"github.com/kartverket/skiperator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func CreatePodSpec(container corev1.Container, volumes []corev1.Volume, serviceAccountName string, priority string, policy *corev1.RestartPolicy) corev1.PodSpec {
+	return corev1.PodSpec{
+		Volumes: volumes,
+		Containers: []corev1.Container{
+			container,
+		},
+		ServiceAccountName: serviceAccountName,
+		SecurityContext: &corev1.PodSecurityContext{
+			SupplementalGroups: []int64{util.SkiperatorUser},
+			FSGroup:            util.PointTo(util.SkiperatorUser),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
+		ImagePullSecrets:  []corev1.LocalObjectReference{{Name: "github-auth"}},
+		PriorityClassName: fmt.Sprintf("skip-%s", priority),
+		RestartPolicy:     *policy,
+	}
+
+}
+
+func CreateApplicationContainer(application *skiperatorv1alpha1.Application) corev1.Container {
+	return corev1.Container{
+		Name:            application.Name,
+		Image:           application.Spec.Image,
+		ImagePullPolicy: corev1.PullAlways,
+		Command:         application.Spec.Command,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged:               util.PointTo(false),
+			AllowPrivilegeEscalation: util.PointTo(false),
+			ReadOnlyRootFilesystem:   util.PointTo(true),
+			RunAsUser:                util.PointTo(util.SkiperatorUser),
+			RunAsGroup:               util.PointTo(util.SkiperatorUser),
+		},
+		Ports:                    getContainerPorts(application),
+		EnvFrom:                  getEnvFrom(application.Spec.EnvFrom),
+		Resources:                getResourceRequirements(application.Spec.Resources),
+		Env:                      getEnv(application.Spec.Env),
+		ReadinessProbe:           getProbe(application.Spec.Readiness),
+		LivenessProbe:            getProbe(application.Spec.Liveness),
+		StartupProbe:             getProbe(application.Spec.Startup),
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
+//func CreateJobContainer(skipJob *skiperatorv1alpha1.SKIPJob) corev1.Container {
+//	return corev1.Container{
+//		Name:            util.ResourceNameWithHash(skipJob.Name, skipJob.Kind),
+//		Image:           skipJob.Spec.Container.Image,
+//		ImagePullPolicy: corev1.PullAlways,
+//		Command:         skipJob.Spec.Container.Command,
+//		SecurityContext: &corev1.SecurityContext{
+//			Privileged:               util.PointTo(false),
+//			AllowPrivilegeEscalation: util.PointTo(false),
+//			ReadOnlyRootFilesystem:   util.PointTo(true),
+//			RunAsUser:                util.PointTo(util.SkiperatorUser),
+//			RunAsGroup:               util.PointTo(util.SkiperatorUser),
+//		},
+//		EnvFrom:        getEnvFrom(skipJob.Spec.Container.EnvFrom),
+//		Resources:      getResourceRequirements(skipJob.Spec.Container.Resources),
+//		Env:            skipJob.Spec.Container.Env,
+//		ReadinessProbe: getProbe(skipJob.Spec.Container.Readiness),
+//		LivenessProbe:  getProbe(skipJob.Spec.Container.Liveness),
+//		StartupProbe:   getProbe(skipJob.Spec.Container.Startup),
+//	}
+//}
+
+func getProbe(appProbe *podtypes.Probe) *corev1.Probe {
+	if appProbe != nil {
+		probe := corev1.Probe{
+			InitialDelaySeconds: appProbe.InitialDelay,
+			TimeoutSeconds:      appProbe.Timeout,
+			FailureThreshold:    appProbe.FailureThreshold,
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: appProbe.Path,
+					Port: appProbe.Port,
+				},
+			},
+		}
+
+		return &probe
+	}
+
+	return nil
+}
+
+func getResourceRequirements(resources *podtypes.ResourceRequirements) corev1.ResourceRequirements {
+	if resources == nil {
+		return corev1.ResourceRequirements{}
+	}
+
+	return corev1.ResourceRequirements{
+		Limits:   (*resources).Limits,
+		Requests: (*resources).Requests,
+	}
+}
+
+func getEnvFrom(envFromApplication []podtypes.EnvFrom) []corev1.EnvFromSource {
+	var envFromSource []corev1.EnvFromSource
+
+	for _, env := range envFromApplication {
+		if len(env.ConfigMap) > 0 {
+			envFromSource = append(envFromSource,
+				corev1.EnvFromSource{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: env.ConfigMap,
+						},
+					},
+				},
+			)
+		} else if len(env.Secret) > 0 {
+			envFromSource = append(envFromSource,
+				corev1.EnvFromSource{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: env.Secret,
+						},
+					},
+				},
+			)
+		}
+	}
+
+	return envFromSource
+}
+
+func getEnv(variables []corev1.EnvVar) []corev1.EnvVar {
+	for _, variable := range variables {
+		if variable.ValueFrom != nil {
+			if variable.ValueFrom.FieldRef != nil {
+				variable.ValueFrom.FieldRef.APIVersion = "v1"
+			}
+		}
+	}
+
+	return variables
+}
+
+func getContainerPorts(application *skiperatorv1alpha1.Application) []corev1.ContainerPort {
+
+	containerPorts := []corev1.ContainerPort{
+		{
+			Name:          "main",
+			ContainerPort: int32(application.Spec.Port),
+		},
+	}
+
+	for _, port := range application.Spec.AdditionalPorts {
+		containerPorts = append(containerPorts, corev1.ContainerPort{
+			ContainerPort: port.Port,
+			Name:          port.Name,
+			Protocol:      port.Protocol,
+		})
+	}
+
+	return containerPorts
+}

--- a/pkg/resourcegenerator/istio/peer_authentication.go
+++ b/pkg/resourcegenerator/istio/peer_authentication.go
@@ -1,0 +1,18 @@
+package istio
+
+import (
+	"github.com/kartverket/skiperator/pkg/util"
+	securityv1beta1api "istio.io/api/security/v1beta1"
+	typev1beta1 "istio.io/api/type/v1beta1"
+)
+
+func GetPeerAuthentication(ownerName string) securityv1beta1api.PeerAuthentication {
+	return securityv1beta1api.PeerAuthentication{
+		Selector: &typev1beta1.WorkloadSelector{
+			MatchLabels: util.GetPodAppSelector(ownerName),
+		},
+		Mtls: &securityv1beta1api.PeerAuthentication_MutualTLS{
+			Mode: securityv1beta1api.PeerAuthentication_MutualTLS_STRICT,
+		},
+	}
+}

--- a/pkg/resourcegenerator/istio/service_entry.go
+++ b/pkg/resourcegenerator/istio/service_entry.go
@@ -1,0 +1,88 @@
+package istio
+
+import (
+	"fmt"
+	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
+	"github.com/kartverket/skiperator/pkg/util"
+	networkingv1beta1api "istio.io/api/networking/v1beta1"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"regexp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetServiceEntries(accessPolicy *podtypes.AccessPolicy, object client.Object) []networkingv1beta1.ServiceEntry {
+	var serviceEntries []networkingv1beta1.ServiceEntry
+
+	if accessPolicy != nil {
+		for _, rule := range (*accessPolicy).Outbound.External {
+			serviceEntryNamePrefix := fmt.Sprintf("%s-egress-%x", object.GetName(), util.GenerateHashFromName(rule.Host))
+			serviceEntryName := util.ResourceNameWithHash(serviceEntryNamePrefix, object.GetObjectKind().GroupVersionKind().Kind)
+			resolution, addresses, endpoints := getIpData(rule.Ip)
+
+			serviceEntry := networkingv1beta1.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: object.GetNamespace(),
+					Name:      serviceEntryName,
+				},
+				Spec: networkingv1beta1api.ServiceEntry{
+					// Avoid leaking service entry to other namespaces
+					ExportTo:   []string{".", "istio-system", "istio-gateways"},
+					Hosts:      []string{rule.Host},
+					Resolution: resolution,
+					Addresses:  addresses,
+					Endpoints:  endpoints,
+					Ports:      getPorts(rule.Ports, rule.Ip),
+				},
+			}
+
+			serviceEntries = append(serviceEntries, serviceEntry)
+		}
+	}
+
+	return serviceEntries
+}
+
+func getPorts(externalPorts []podtypes.ExternalPort, ruleIP string) []*networkingv1beta1api.Port {
+	var ports []*networkingv1beta1api.Port
+
+	if len(externalPorts) == 0 {
+		ports = append(ports, &networkingv1beta1api.Port{
+			Name:     "https",
+			Number:   uint32(443),
+			Protocol: "HTTPS",
+		})
+
+		return ports
+	}
+
+	for _, port := range externalPorts {
+		if ruleIP == "" && port.Protocol == "TCP" {
+			continue
+		}
+
+		ports = append(ports, &networkingv1beta1api.Port{
+			Name:     port.Name,
+			Number:   uint32(port.Port),
+			Protocol: port.Protocol,
+		})
+
+	}
+
+	return ports
+}
+
+func getIpData(ip string) (networkingv1beta1api.ServiceEntry_Resolution, []string, []*networkingv1beta1api.WorkloadEntry) {
+	if ip == "" {
+		return networkingv1beta1api.ServiceEntry_DNS, nil, nil
+	}
+
+	return networkingv1beta1api.ServiceEntry_STATIC, []string{ip}, []*networkingv1beta1api.WorkloadEntry{{Address: ip}}
+}
+
+// Filter for service entries named like *-egress-*
+func IsEgressServiceEntry(serviceEntry *networkingv1beta1.ServiceEntry) bool {
+	match, _ := regexp.MatchString("^.*-egress-.*$", serviceEntry.Name)
+
+	return match
+}

--- a/pkg/resourcegenerator/networking/network_policy.go
+++ b/pkg/resourcegenerator/networking/network_policy.go
@@ -26,10 +26,6 @@ type NetPolOpts struct {
 }
 
 func CreateNetPolSpec(opts NetPolOpts) *networkingv1.NetworkPolicySpec {
-	if opts.AccessPolicy == nil {
-		return nil
-	}
-
 	ingressRules := getIngressRules(opts.AccessPolicy, opts.Ingresses, opts.Port, opts.Namespace, opts.PrometheusConfig)
 	egressRules := getEgressRules(opts.AccessPolicy, opts.Namespace, *opts.RelatedServices)
 
@@ -159,7 +155,7 @@ func getIngressRules(accessPolicy *podtypes.AccessPolicy, ingresses *[]string, p
 		ingressRules = append(ingressRules, promScrapeRule)
 	}
 
-	if accessPolicy == nil && port == nil {
+	if accessPolicy == nil {
 		return ingressRules
 	}
 

--- a/pkg/resourcegenerator/networking/network_policy.go
+++ b/pkg/resourcegenerator/networking/network_policy.go
@@ -1,0 +1,266 @@
+package networking
+
+import (
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
+	"github.com/kartverket/skiperator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	GrafanaAgentName      = "grafana-agent"
+	GrafanaAgentNamespace = GrafanaAgentName
+)
+
+type NetPolOpts struct {
+	AccessPolicy     *podtypes.AccessPolicy
+	Ingresses        *[]string
+	Port             *int
+	RelatedServices  *[]corev1.Service
+	Namespace        string
+	Name             string
+	PrometheusConfig *skiperatorv1alpha1.PrometheusConfig
+}
+
+func CreateNetPolSpec(opts NetPolOpts) *networkingv1.NetworkPolicySpec {
+	if opts.AccessPolicy == nil {
+		return nil
+	}
+
+	ingressRules := getIngressRules(opts.AccessPolicy, opts.Ingresses, opts.Port, opts.Namespace, opts.PrometheusConfig)
+	egressRules := getEgressRules(opts.AccessPolicy, opts.Namespace, *opts.RelatedServices)
+
+	if len(ingressRules) > 0 || len(egressRules) > 0 {
+		return &networkingv1.NetworkPolicySpec{
+			PolicyTypes: getPolicyTypes(ingressRules, egressRules),
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: util.GetPodAppSelector(opts.Name),
+			},
+			Ingress: ingressRules,
+			Egress:  egressRules,
+		}
+	}
+
+	return nil
+}
+
+func getPolicyTypes(ingressRules []networkingv1.NetworkPolicyIngressRule, egressRules []networkingv1.NetworkPolicyEgressRule) []networkingv1.PolicyType {
+	var policyType []networkingv1.PolicyType
+
+	if len(ingressRules) > 0 {
+		policyType = append(policyType, networkingv1.PolicyTypeIngress)
+	}
+
+	if len(egressRules) > 0 {
+		policyType = append(policyType, networkingv1.PolicyTypeEgress)
+	}
+
+	return policyType
+}
+
+func getEgressRules(accessPolicy *podtypes.AccessPolicy, namespace string, availableServices []corev1.Service) []networkingv1.NetworkPolicyEgressRule {
+	var egressRules []networkingv1.NetworkPolicyEgressRule
+
+	// Egress rules for internal peers
+	if accessPolicy == nil || availableServices == nil {
+		return egressRules
+	}
+
+	for _, outboundRule := range (*accessPolicy).Outbound.Rules {
+		if outboundRule.Namespace == "" {
+			outboundRule.Namespace = namespace
+		}
+
+		relatedService, isApplicationAvailable := getRelatedService(availableServices, outboundRule)
+
+		if !isApplicationAvailable {
+			continue
+		} else {
+			var servicePorts []networkingv1.NetworkPolicyPort
+
+			for _, port := range relatedService.Spec.Ports {
+				servicePorts = append(servicePorts, networkingv1.NetworkPolicyPort{
+					Port: util.PointTo(intstr.FromInt(int(port.Port))),
+				})
+			}
+
+			egressRuleForOutboundRule := networkingv1.NetworkPolicyEgressRule{
+				Ports: servicePorts,
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: relatedService.Spec.Selector,
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": outboundRule.Namespace},
+						},
+					},
+				},
+			}
+
+			egressRules = append(egressRules, egressRuleForOutboundRule)
+		}
+
+	}
+
+	return egressRules
+}
+
+func getRelatedService(services []corev1.Service, rule podtypes.InternalRule) (corev1.Service, bool) {
+	for _, service := range services {
+		if service.Name == rule.Application && service.Namespace == rule.Namespace {
+			return service, true
+
+		}
+	}
+
+	return corev1.Service{}, false
+}
+
+func getIngressRules(accessPolicy *podtypes.AccessPolicy, ingresses *[]string, port *int, namespace string, prometheusConfig *skiperatorv1alpha1.PrometheusConfig) []networkingv1.NetworkPolicyIngressRule {
+	var ingressRules []networkingv1.NetworkPolicyIngressRule
+
+	if ingresses != nil && port != nil && len(*ingresses) > 0 {
+		if hasInternalIngress(*ingresses) {
+			ingressRules = append(ingressRules, getGatewayIngressRule(*port, true))
+		}
+
+		if hasExternalIngress(*ingresses) {
+			ingressRules = append(ingressRules, getGatewayIngressRule(*port, false))
+		}
+	}
+
+	// If Prometheus metrics are exposed, allow grafana-agent to scrape
+	if prometheusConfig != nil {
+		promScrapeRule := networkingv1.NetworkPolicyIngressRule{
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": GrafanaAgentNamespace},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/instance": GrafanaAgentName,
+							"app.kubernetes.io/name":     GrafanaAgentName,
+						},
+					},
+				},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Port: determinePrometheusScrapePort(prometheusConfig),
+				},
+			},
+		}
+
+		ingressRules = append(ingressRules, promScrapeRule)
+	}
+
+	if accessPolicy == nil && port == nil {
+		return ingressRules
+	}
+
+	if len((*accessPolicy).Inbound.Rules) > 0 {
+		inboundTrafficIngressRule := networkingv1.NetworkPolicyIngressRule{
+			From: getInboundPolicyPeers(accessPolicy.Inbound.Rules, namespace),
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Port: util.PointTo(intstr.FromInt(*port)),
+				},
+			},
+		}
+
+		ingressRules = append(ingressRules, inboundTrafficIngressRule)
+	}
+
+	return ingressRules
+}
+
+func getInboundPolicyPeers(inboundRules []podtypes.InternalRule, namespace string) []networkingv1.NetworkPolicyPeer {
+	var policyPeers []networkingv1.NetworkPolicyPeer
+
+	for _, inboundRule := range inboundRules {
+		if inboundRule.Namespace == "" {
+			inboundRule.Namespace = namespace
+		}
+
+		policyPeers = append(policyPeers, networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/metadata.name": inboundRule.Namespace},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": inboundRule.Application},
+			},
+		})
+	}
+
+	return policyPeers
+}
+
+func hasExternalIngress(ingresses []string) bool {
+	for _, hostname := range ingresses {
+		if !util.IsInternal(hostname) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasInternalIngress(ingresses []string) bool {
+	for _, hostname := range ingresses {
+		if util.IsInternal(hostname) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getGatewayIngressRule(port int, isInternal bool) networkingv1.NetworkPolicyIngressRule {
+	ingressRule := networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "istio-gateways"},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: getIngressGatewayLabel(isInternal),
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{
+				Port: util.PointTo(intstr.FromInt(port)),
+			},
+		},
+	}
+
+	return ingressRule
+}
+
+func getIngressGatewayLabel(isInternal bool) map[string]string {
+	if isInternal {
+		return map[string]string{"app": "istio-ingress-internal"}
+	} else {
+		return map[string]string{"app": "istio-ingress-external"}
+	}
+}
+
+func determinePrometheusScrapePort(prometheusConfig *skiperatorv1alpha1.PrometheusConfig) *intstr.IntOrString {
+	if IstioEnabled(prometheusConfig) {
+		return util.PointTo(util.IstioMetricsPortName)
+	}
+	return util.PointTo(prometheusConfig.Port)
+}
+
+func IstioEnabled(prometheusConfig *skiperatorv1alpha1.PrometheusConfig) bool {
+	if prometheusConfig == nil {
+		return false
+	}
+
+	return *prometheusConfig.IstioEnabled
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,5 +1,7 @@
 package util
 
+import "k8s.io/apimachinery/pkg/util/intstr"
+
 var CommonAnnotations = map[string]string{
 	// Prevents Argo CD from deleting these resources and leaving the namespace
 	// in a deadlocked deleting state
@@ -8,3 +10,9 @@ var CommonAnnotations = map[string]string{
 }
 
 const SkiperatorUser = int64(150)
+
+var (
+	IstioMetricsPortNumber = intstr.FromInt(15020)
+	IstioMetricsPortName   = intstr.FromString("istio-metrics")
+	IstioMetricsPath       = "/stats/prometheus"
+)

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/hashstructure/v2"
 	"hash/fnv"
 	"regexp"
+	"strconv"
 	"unicode"
 
 	"golang.org/x/exp/maps"
@@ -78,7 +79,7 @@ func PointTo[T any](x T) *T {
 	return &x
 }
 
-func GetApplicationSelector(applicationName string) map[string]string {
+func GetPodAppSelector(applicationName string) map[string]string {
 	return map[string]string{"app": applicationName}
 }
 
@@ -90,4 +91,10 @@ func HasUpperCaseLetter(word string) bool {
 	}
 
 	return false
+}
+
+func ResourceNameWithHash(resourceName string, kind string) string {
+	hash := GenerateHashFromName(resourceName + kind)
+
+	return resourceName + "-" + strconv.FormatUint(hash, 16)
 }

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/mitchellh/hashstructure/v2"
+	"github.com/r3labs/diff/v3"
 	"hash/fnv"
+	"reflect"
 	"regexp"
 	"strconv"
 	"unicode"
@@ -97,4 +99,20 @@ func ResourceNameWithHash(resourceName string, kind string) string {
 	hash := GenerateHashFromName(resourceName + kind)
 
 	return resourceName + "-" + strconv.FormatUint(hash, 16)
+}
+
+func GetObjectDiff[T any](a T, b T) {
+	aKind := reflect.ValueOf(a).Kind()
+	bKind := reflect.ValueOf(b).Kind()
+	if aKind != bKind {
+		fmt.Printf("The objects to compare are not the same, found obj1: %v, obj2: %v\n", aKind, bKind)
+		return
+	}
+	changelog, _ := diff.Diff(a, b)
+
+	if len(changelog) == 0 {
+		fmt.Printf("No changes found\n")
+	}
+
+	fmt.Printf("Changes found: \n%v", changelog)
 }

--- a/samples/application.yaml
+++ b/samples/application.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: sample
   name: sample-one
 spec:
-  image: "image"
+  image: "quay.io/brancz/prometheus-example-app:v0.4.0"
 
   port: 8080
 

--- a/tests/minimal/00-assert.yaml
+++ b/tests/minimal/00-assert.yaml
@@ -83,18 +83,6 @@ spec:
       protocol: TCP
       appProtocol: http
 ---
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: minimal
-spec:
-  podSelector:
-    matchLabels:
-      app: minimal
-  policyTypes:
-    - Ingress
-    - Egress
----
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:

--- a/tests/service-monitor/00-assert.yaml
+++ b/tests/service-monitor/00-assert.yaml
@@ -66,7 +66,6 @@ spec:
       app: some-monitored-app-1
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - namespaceSelector:
@@ -107,7 +106,6 @@ spec:
       app: some-monitored-app-2
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - namespaceSelector:
@@ -148,7 +146,6 @@ spec:
       app: some-monitored-app-3
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - namespaceSelector:

--- a/tests/service-monitor/02-assert.yaml
+++ b/tests/service-monitor/02-assert.yaml
@@ -107,7 +107,6 @@ spec:
       app: some-monitored-app-3
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - namespaceSelector:

--- a/tests/service-monitor/02-assert.yaml
+++ b/tests/service-monitor/02-assert.yaml
@@ -39,18 +39,6 @@ spec:
       protocol: TCP
       appProtocol: http
 ---
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: some-monitored-app-1
-spec:
-  podSelector:
-    matchLabels:
-      app: some-monitored-app-1
-  policyTypes:
-    - Ingress
-    - Egress
----
 # 2
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -79,7 +67,6 @@ spec:
       app: some-monitored-app-2
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - namespaceSelector:

--- a/tests/service-monitor/04-assert.yaml
+++ b/tests/service-monitor/04-assert.yaml
@@ -82,7 +82,6 @@ spec:
       app: some-monitored-app-1
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - namespaceSelector:


### PR DESCRIPTION
Extracts some functions which generate resources to its own library. Avoids having the future SKIPJob controller fetch from the Application controller package, instead creating a new one. Only done for resources which will be used by SKIPJobs in the future, see #227

Not sure where exactly to put the istio constants and the `IstioEnabled()` function. If there are any inputs as to where this should be placed let me know :)