### PR TITLE
Fix wordy "could not init status" error message on Application init

### DIFF
--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -149,8 +149,6 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	r.EmitNormalEvent(application, "ReconcileStart", fmt.Sprintf("Application %v has started reconciliation loop", application.Name))
 
 	controllerDuties := []func(context.Context, *skiperatorv1alpha1.Application) (reconcile.Result, error){
-		//r.initializeApplicationStatus,
-		//r.initializeApplication,
 		r.reconcileCertificate,
 		r.reconcileService,
 		r.reconcileConfigMap,

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -53,7 +53,7 @@ const applicationFinalizer = "skip.statkart.no/finalizer"
 
 func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&skiperatorv1alpha1.Application{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&skiperatorv1alpha1.Application{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
@@ -70,7 +70,7 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&securityv1beta1.AuthorizationPolicy{}).
 		Owns(&pov1.ServiceMonitor{}).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(r.SkiperatorOwnedCertRequests)).
-		//WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
Some weird interactions with finalizer currently, not sure why.

Would love to be able to remove the annoying 
```
{"controller": "skipjob", "controllerGroup": "skiperator.kartverket.no", "controllerKind": "SKIPJob", "SKIPJob": {"name":"condition-finish","namespace":"test"}, "namespace": "test", "name": "condition-finish", "reconcileID": "49b70cf2-d983-46be-b125-c8ae25b449e9", "error": "Operation cannot be fulfilled on skipjobs.skiperator.kartverket.no \"condition-finish\": StorageError: invalid object, Code: 4, Key: /registry/skiperator.kartverket.no/skipjobs/test/condition-finish, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 23dff9d9-88ab-45e9-8a2f-798562f4960b, UID in object meta: "}
```

error was well, but not sure why it's happening. something going on when deleting applications