### PR TITLE
Fix bug in mutable and shared annotations

### DIFF
--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -28,11 +28,7 @@ const (
 )
 
 var (
-	deploymentLog         = ctrl.Log.WithName("deployment")
-	defaultPodAnnotations = map[string]string{
-		"argocd.argoproj.io/sync-options": "Prune=false",
-		"prometheus.io/scrape":            "true",
-	}
+	deploymentLog = ctrl.Log.WithName("deployment")
 )
 
 func (r *ApplicationReconciler) defineDeployment(ctx context.Context, application *skiperatorv1alpha1.Application) (appsv1.Deployment, error) {
@@ -85,7 +81,10 @@ func (r *ApplicationReconciler) defineDeployment(ctx context.Context, applicatio
 
 	labels := util.GetPodAppSelector(application.Name)
 
-	generatedSpecAnnotations := defaultPodAnnotations
+	generatedSpecAnnotations := map[string]string{
+		"argocd.argoproj.io/sync-options": "Prune=false",
+		"prometheus.io/scrape":            "true",
+	}
 	// By specifying port and path annotations, Istio will scrape metrics from the application
 	// and merge it together with its own metrics.
 	//


### PR DESCRIPTION
When a reconciliation loop adds a new annotation to the map it is silently reused for other apps reconciling at a later time.

This leads to a case where an app who doesn't have a Prometheus block specified gets attempted scraped at the previous reconciled app's (with Prometheus config) port and path.


FYI @christianmosveen 

SKIP-1134