### PR TITLE
SKIP-1084 Allow namespace-labels in AccessPolicies

### DIFF
--- a/api/v1alpha1/podtypes/access_policy.go
+++ b/api/v1alpha1/podtypes/access_policy.go
@@ -1,5 +1,9 @@
 package podtypes
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // +kubebuilder:object:generate=true
 type AccessPolicy struct {
 	//+kubebuilder:validation:Optional
@@ -27,6 +31,8 @@ type InternalRule struct {
 	Namespace string `json:"namespace,omitempty"`
 	//+kubebuilder:validation:Required
 	Application string `json:"application"`
+	//+kubebuilder:validation:Optional
+	NamespacesByLabel *metav1.LabelSelector `json:"namespaceByLabel,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/pkg/resourcegenerator/networking/network_policy.go
+++ b/pkg/resourcegenerator/networking/network_policy.go
@@ -185,9 +185,7 @@ func getInboundPolicyPeers(inboundRules []podtypes.InternalRule, namespace strin
 		}
 
 		policyPeers = append(policyPeers, networkingv1.NetworkPolicyPeer{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"kubernetes.io/metadata.name": inboundRule.Namespace},
-			},
+			NamespaceSelector: getNamespaceSelector(inboundRule),
 			PodSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": inboundRule.Application},
 			},
@@ -195,6 +193,16 @@ func getInboundPolicyPeers(inboundRules []podtypes.InternalRule, namespace strin
 	}
 
 	return policyPeers
+}
+
+func getNamespaceSelector(rule podtypes.InternalRule) *metav1.LabelSelector {
+	if rule.NamespacesByLabel != nil {
+		return rule.NamespacesByLabel
+	} else {
+		return &metav1.LabelSelector{
+			MatchLabels: map[string]string{"kubernetes.io/metadata.name": rule.Namespace},
+		}
+	}
 }
 
 func hasExternalIngress(ingresses []string) bool {


### PR DESCRIPTION
Added test for using namespace-labels to generate AccessPolicy rules instead of managing large lists of namespaces manually