### PR TITLE
Added labels to deployment pod template spec

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -9,7 +9,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strings"
 	"time"
 )
 
@@ -336,89 +335,5 @@ func max[T constraints.Ordered](a, b T) T {
 		return a
 	} else {
 		return b
-	}
-}
-
-type ControllerResources string
-
-const (
-	DEPLOYMENT              ControllerResources = "Deployment"
-	SERVICE                 ControllerResources = "Service"
-	SERVICEACCOUNT          ControllerResources = "ServiceAccount"
-	CONFIGMAP               ControllerResources = "ConfigMap"
-	NETWORKPOLICY           ControllerResources = "NetworkPolicy"
-	GATEWAY                 ControllerResources = "Gateway"
-	SERVICEENTRY            ControllerResources = "ServiceEntry"
-	VIRTUALSERVICE          ControllerResources = "VirtualService"
-	PEERAUTHENTICATION      ControllerResources = "PeerAuthentication"
-	HORIZONTALPODAUTOSCALER ControllerResources = "HorizontalPodAutoscaler"
-	CERTIFICATE             ControllerResources = "Certificate"
-	AUTHORIZATIONPOLICY     ControllerResources = "AuthorizationPolicy"
-)
-
-func (a *Application) GroupKindFromControllerResource(controllerResource string) (metav1.GroupKind, bool) {
-	switch strings.ToLower(controllerResource) {
-	case "deployment":
-		return metav1.GroupKind{
-			Group: "apps",
-			Kind:  string(DEPLOYMENT),
-		}, true
-	case "service":
-		return metav1.GroupKind{
-			Group: "",
-			Kind:  string(SERVICE),
-		}, true
-	case "serviceaccount":
-		return metav1.GroupKind{
-			Group: "",
-			Kind:  string(SERVICEACCOUNT),
-		}, true
-	case "configmaps":
-		return metav1.GroupKind{
-			Group: "",
-			Kind:  string(CONFIGMAP),
-		}, true
-	case "networkpolicy":
-		return metav1.GroupKind{
-			Group: "networking.k8s.io",
-			Kind:  string(NETWORKPOLICY),
-		}, true
-	case "gateway":
-		return metav1.GroupKind{
-			Group: "networking.istio.io",
-			Kind:  string(GATEWAY),
-		}, true
-	case "serviceentry":
-		return metav1.GroupKind{
-			Group: "networking.istio.io",
-			Kind:  string(SERVICEENTRY),
-		}, true
-	case "virtualservice":
-		return metav1.GroupKind{
-			Group: "networking.istio.io",
-			Kind:  string(VIRTUALSERVICE),
-		}, true
-	case "peerauthentication":
-		return metav1.GroupKind{
-			Group: "security.istio.io",
-			Kind:  string(PEERAUTHENTICATION),
-		}, true
-	case "horizontalpodautoscaler":
-		return metav1.GroupKind{
-			Group: "autoscaling",
-			Kind:  string(HORIZONTALPODAUTOSCALER),
-		}, true
-	case "certificate":
-		return metav1.GroupKind{
-			Group: "cert-manager.io",
-			Kind:  string(CERTIFICATE),
-		}, true
-	case "authorizationpolicy":
-		return metav1.GroupKind{
-			Group: "security.istio.io",
-			Kind:  string(AUTHORIZATIONPOLICY),
-		}, true
-	default:
-		return metav1.GroupKind{}, false
 	}
 }

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -288,11 +288,84 @@ func (r *ApplicationReconciler) SetControllerFinishedOutcome(context context.Con
 	return r.SetControllerSynced(context, app, controllerName)
 }
 
+type ControllerResources string
+
+const (
+	DEPLOYMENT              ControllerResources = "Deployment"
+	POD                     ControllerResources = "Pod"
+	SERVICE                 ControllerResources = "Service"
+	SERVICEACCOUNT          ControllerResources = "ServiceAccount"
+	CONFIGMAP               ControllerResources = "ConfigMap"
+	NETWORKPOLICY           ControllerResources = "NetworkPolicy"
+	GATEWAY                 ControllerResources = "Gateway"
+	SERVICEENTRY            ControllerResources = "ServiceEntry"
+	VIRTUALSERVICE          ControllerResources = "VirtualService"
+	PEERAUTHENTICATION      ControllerResources = "PeerAuthentication"
+	HORIZONTALPODAUTOSCALER ControllerResources = "HorizontalPodAutoscaler"
+	CERTIFICATE             ControllerResources = "Certificate"
+	AUTHORIZATIONPOLICY     ControllerResources = "AuthorizationPolicy"
+)
+
+var GroupKindFromControllerResource = map[string]metav1.GroupKind{
+	"deployment": {
+		Group: "apps",
+		Kind:  string(DEPLOYMENT),
+	},
+	"pod": {
+		Group: "",
+		Kind:  string(POD),
+	},
+	"service": {
+		Group: "",
+		Kind:  string(SERVICE),
+	},
+	"serviceaccount": {
+		Group: "",
+		Kind:  string(SERVICEACCOUNT),
+	},
+	"configmaps": {
+		Group: "",
+		Kind:  string(CONFIGMAP),
+	},
+	"networkpolicy": {
+		Group: "networking.k8s.io",
+		Kind:  string(NETWORKPOLICY),
+	},
+	"gateway": {
+		Group: "networking.istio.io",
+		Kind:  string(GATEWAY),
+	},
+	"serviceentry": {
+		Group: "networking.istio.io",
+		Kind:  string(SERVICEENTRY),
+	},
+	"virtualservice": {
+		Group: "networking.istio.io",
+		Kind:  string(VIRTUALSERVICE),
+	},
+	"peerauthentication": {
+		Group: "security.istio.io",
+		Kind:  string(PEERAUTHENTICATION),
+	},
+	"horizontalpodautoscaler": {
+		Group: "autoscaling",
+		Kind:  string(HORIZONTALPODAUTOSCALER),
+	},
+	"certificate": {
+		Group: "cert-manager.io",
+		Kind:  string(CERTIFICATE),
+	},
+	"authorizationpolicy": {
+		Group: "security.istio.io",
+		Kind:  string(AUTHORIZATIONPOLICY),
+	},
+}
+
 func (r *ApplicationReconciler) setResourceLabelsIfApplies(obj client.Object, app skiperatorv1alpha1.Application) {
 	objectGroupVersionKind := obj.GetObjectKind().GroupVersionKind()
 
 	for controllerResource, resourceLabels := range app.Spec.ResourceLabels {
-		resourceLabelGroupKind, present := app.GroupKindFromControllerResource(controllerResource)
+		resourceLabelGroupKind, present := GroupKindFromControllerResource[strings.ToLower(controllerResource)]
 		if present {
 			if strings.EqualFold(objectGroupVersionKind.Group, resourceLabelGroupKind.Group) && strings.EqualFold(objectGroupVersionKind.Kind, resourceLabelGroupKind.Kind) {
 				objectLabels := obj.GetLabels()
@@ -320,37 +393,3 @@ func (r *ApplicationReconciler) SetLabelsFromApplication(object client.Object, a
 
 	r.setResourceLabelsIfApplies(object, app)
 }
-
-
-func (r *ApplicationReconciler) setPodResourceLabelsIfApplies(obj corev1.PodTemplateSpec, app skiperatorv1alpha1.Application) {
-
-	for controllerResource, resourceLabels := range app.Spec.ResourceLabels {
-		resourceLabelGroupKind, present := app.GroupKindFromControllerResource(controllerResource)
-		if present {
-			if strings.EqualFold("core", resourceLabelGroupKind.Group) && strings.EqualFold("Pod", resourceLabelGroupKind.Kind) {
-				objectLabels := obj.GetLabels()
-				if len(objectLabels) == 0 {
-					objectLabels = make(map[string]string)
-				}
-				maps.Copy(objectLabels, resourceLabels)
-				obj.SetLabels(objectLabels)
-			}
-		} else {
-			r.EmitWarningEvent(&app, "MistypedLabel", fmt.Sprintf("could not find according Kind for Resource %v, make sure your resource is spelled correctly", controllerResource))
-		}
-	}
-}
-
-func (r *ApplicationReconciler) SetPodLabelsFromApplication(object corev1.PodTemplateSpec, app skiperatorv1alpha1.Application) {
-	labels := object.GetLabels()
-	if len(labels) == 0 {
-		labels = make(map[string]string)
-	}
-	if app.Spec.Labels != nil {
-		maps.Copy(labels, app.Spec.Labels)
-		object.SetLabels(labels)
-	}
-
-	r.setPodResourceLabelsIfApplies(object, app)
-}
-

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -97,43 +97,46 @@ func (r *ApplicationReconciler) defineDeployment(ctx context.Context, applicatio
 		generatedSpecAnnotations["prometheus.io/path"] = application.Spec.Prometheus.Path
 	}
 
+	podSpec := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      labels,
+			Annotations: generatedSpecAnnotations,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				skiperatorContainer,
+			},
+
+			// TODO: Make this as part of operator in a safe way
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "github-auth"}},
+			SecurityContext: &corev1.PodSecurityContext{
+				SupplementalGroups: []int64{util.SkiperatorUser},
+				FSGroup:            util.PointTo(util.SkiperatorUser),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			ServiceAccountName: application.Name,
+			// The resulting kubernetes object includes the ServiceAccount field, and thus it's required in order
+			// to not create a diff for the hash of existing and wanted spec
+			DeprecatedServiceAccount:      application.Name,
+			Volumes:                       podVolumes,
+			PriorityClassName:             fmt.Sprintf("skip-%s", application.Spec.Priority),
+			RestartPolicy:                 corev1.RestartPolicyAlways,
+			TerminationGracePeriodSeconds: util.PointTo(int64(corev1.DefaultTerminationGracePeriodSeconds)),
+			DNSPolicy:                     corev1.DNSClusterFirst,
+			SchedulerName:                 corev1.DefaultSchedulerName,
+		},
+	}
+	r.SetPodLabelsFromApplication(podSpec, *application)
+
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{MatchLabels: labels},
 		Strategy: appsv1.DeploymentStrategy{
 			Type:          appsv1.DeploymentStrategyType(application.Spec.Strategy.Type),
 			RollingUpdate: getRollingUpdateStrategy(application.Spec.Strategy.Type),
 		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels:      labels,
-				Annotations: generatedSpecAnnotations,
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					skiperatorContainer,
-				},
-
-				// TODO: Make this as part of operator in a safe way
-				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "github-auth"}},
-				SecurityContext: &corev1.PodSecurityContext{
-					SupplementalGroups: []int64{util.SkiperatorUser},
-					FSGroup:            util.PointTo(util.SkiperatorUser),
-					SeccompProfile: &corev1.SeccompProfile{
-						Type: corev1.SeccompProfileTypeRuntimeDefault,
-					},
-				},
-				ServiceAccountName: application.Name,
-				// The resulting kubernetes object includes the ServiceAccount field, and thus it's required in order
-				// to not create a diff for the hash of existing and wanted spec
-				DeprecatedServiceAccount:      application.Name,
-				Volumes:                       podVolumes,
-				PriorityClassName:             fmt.Sprintf("skip-%s", application.Spec.Priority),
-				RestartPolicy:                 corev1.RestartPolicyAlways,
-				TerminationGracePeriodSeconds: util.PointTo(int64(corev1.DefaultTerminationGracePeriodSeconds)),
-				DNSPolicy:                     corev1.DNSClusterFirst,
-				SchedulerName:                 corev1.DefaultSchedulerName,
-			},
-		},
+		Template: podSpec,
 		RevisionHistoryLimit:    util.PointTo(int32(2)),
 		ProgressDeadlineSeconds: util.PointTo(int32(600)),
 	}

--- a/tests/application/resource-label/00-application.yaml
+++ b/tests/application/resource-label/00-application.yaml
@@ -12,5 +12,7 @@ spec:
       serviceLabel: test
     horizontalpodautoscaler:
       hpaLabel: test
+    Pod:
+      podLabel: test
     thisisnotaresource:
       testLabel: test

--- a/tests/application/resource-label/00-assert.yaml
+++ b/tests/application/resource-label/00-assert.yaml
@@ -9,6 +9,13 @@ kind: Deployment
 metadata:
   labels:
     deploymentLabel: test
+
+# Not created due to mocked control plane
+#apiVersion: v1
+#kind: Pod
+#metadata:
+#  labels:
+#    podLabel: test
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -36,5 +36,5 @@ parallel: 1
 namespace: test
 testDirs:
   - tests/application
-#  - tests/namespace
-#  - tests/skipjob
+  - tests/namespace
+  - tests/skipjob

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -36,5 +36,5 @@ parallel: 1
 namespace: test
 testDirs:
   - tests/application
-  - tests/namespace
-  - tests/skipjob
+#  - tests/namespace
+#  - tests/skipjob


### PR DESCRIPTION
Labels field in application definition now propegate correctly to pod template in deployment.


Changes GroupKindFromControllerResource to a map instead of a function as it was essentially already functioning as one.

Uses the standard SetResourceLabelIfApplies by adding Pod to the ControllerResources and adding a map from the resource -> GroupKind.

Had to create a pod and extract the template, as PodTemplateSpec does not implement type Object, which is needed for setting labels.
