### PR TITLE
Fix mergo 'bug'

### DIFF
--- a/api/v1alpha1/skipjob_defaults.go
+++ b/api/v1alpha1/skipjob_defaults.go
@@ -44,17 +44,9 @@ func (skipJob *SKIPJob) setSkipJobDefaults() error {
 	}
 
 	if skipJob.Spec.Cron != nil {
-		defaults.Spec.Cron = skipJob.Spec.Cron
+		defaults.Spec.Cron = &CronSettings{}
 
-		// Due to an error in mergo, bool values are not merged properly. Temporary workaround
-		// Should only be necessary for spec.cron.suspend as it's the only bool that we add by default and merge using mergo
-		// See: https://github.com/darccio/mergo/issues/237
-		//defaults.Spec.Cron.Suspend = util.PointTo(false)
-		if skipJob.Spec.Cron.Suspend != nil {
-			defaults.Spec.Cron.Suspend = skipJob.Spec.Cron.Suspend
-		} else {
-			defaults.Spec.Cron.Suspend = util.PointTo(DefaultSuspend)
-		}
+		defaults.Spec.Cron.Suspend = util.PointTo(false)
 	}
 
 	return mergo.Merge(skipJob, defaults)


### PR DESCRIPTION
It was not a bug, but rather the result of some poor programming on my end.

Both the source and destination for mergo referred to the same cron struct, so updating the source struct caused the destination to be updated as well, regardless of what mergo did :)