### PR TITLE
Add support for ignoring reconciliation of children

### DIFF
--- a/controllers/application/authorization_policy.go
+++ b/controllers/application/authorization_policy.go
@@ -23,14 +23,9 @@ func (r *ApplicationReconciler) reconcileAuthorizationPolicy(ctx context.Context
 	defaultDenyAuthPolicy := getDefaultDenyPolicy(application, defaultDenyPaths)
 
 	shouldReconcile, err := r.ShouldReconcile(ctx, &defaultDenyAuthPolicy)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	if application.Spec.AuthorizationSettings != nil {

--- a/controllers/application/certificate.go
+++ b/controllers/application/certificate.go
@@ -94,6 +94,16 @@ func (r *ApplicationReconciler) reconcileCertificate(ctx context.Context, applic
 	// Could we get in trouble with shouldReconcile here? I'm not entirely sure
 	for _, certificate := range certificates.Items {
 
+		shouldReconcile, err := r.ShouldReconcile(ctx, &certificate)
+		if err != nil {
+			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+			return reconcile.Result{}, err
+		}
+
+		if !shouldReconcile {
+			continue
+		}
+
 		certificateInApplicationSpecIndex := slices.IndexFunc(application.Spec.Ingresses, func(hostname string) bool {
 			certificateName := fmt.Sprintf("%s-%s-ingress-%x", application.Namespace, application.Name, util.GenerateHashFromName(hostname))
 			return certificate.Name == certificateName

--- a/controllers/application/configmap.go
+++ b/controllers/application/configmap.go
@@ -85,14 +85,9 @@ func (r *ApplicationReconciler) setupGCPAuthConfigMap(ctx context.Context, gcpId
 	}
 
 	shouldReconcile, err := r.ShouldReconcile(ctx, &gcpAuthConfigMap)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return nil
 	}
 
 	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &gcpAuthConfigMap, func() error {

--- a/controllers/application/configmap.go
+++ b/controllers/application/configmap.go
@@ -84,6 +84,17 @@ func (r *ApplicationReconciler) setupGCPAuthConfigMap(ctx context.Context, gcpId
 		return err
 	}
 
+	shouldReconcile, err := r.ShouldReconcile(ctx, &gcpAuthConfigMap)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return err
+	}
+
+	if !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return nil
+	}
+
 	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &gcpAuthConfigMap, func() error {
 		// Set application as owner of the configmap
 		err := ctrlutil.SetControllerReference(application, &gcpAuthConfigMap, r.GetScheme())

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -3,9 +3,10 @@ package applicationcontroller
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"regexp"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	policyv1 "k8s.io/api/policy/v1"
 
@@ -53,22 +54,77 @@ const applicationFinalizer = "skip.statkart.no/finalizer"
 
 func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&skiperatorv1alpha1.Application{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&networkingv1beta1.ServiceEntry{}).
+		For(&skiperatorv1alpha1.Application{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&appsv1.Deployment{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&corev1.Service{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&networkingv1beta1.ServiceEntry{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
 		Owns(&networkingv1beta1.Gateway{}, builder.WithPredicates(
 			util.MatchesPredicate[*networkingv1beta1.Gateway](isIngressGateway),
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
 		)).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&networkingv1beta1.VirtualService{}).
-		Owns(&securityv1beta1.PeerAuthentication{}).
-		Owns(&corev1.ServiceAccount{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&networkingv1.NetworkPolicy{}).
-		Owns(&securityv1beta1.AuthorizationPolicy{}).
-		Owns(&pov1.ServiceMonitor{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&networkingv1beta1.VirtualService{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&securityv1beta1.PeerAuthentication{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&policyv1.PodDisruptionBudget{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&networkingv1.NetworkPolicy{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&securityv1beta1.AuthorizationPolicy{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
+		Owns(&pov1.ServiceMonitor{}, builder.WithPredicates(
+			predicate.Not(
+				util.MatchesPredicate[client.Object](hasIgnoreLabel),
+			),
+		)).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(r.SkiperatorOwnedCertRequests)).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -54,77 +54,22 @@ const applicationFinalizer = "skip.statkart.no/finalizer"
 
 func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&skiperatorv1alpha1.Application{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&corev1.Service{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&networkingv1beta1.ServiceEntry{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
+		For(&skiperatorv1alpha1.Application{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&networkingv1beta1.ServiceEntry{}).
 		Owns(&networkingv1beta1.Gateway{}, builder.WithPredicates(
 			util.MatchesPredicate[*networkingv1beta1.Gateway](isIngressGateway),
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
 		)).
-		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&networkingv1beta1.VirtualService{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&securityv1beta1.PeerAuthentication{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&policyv1.PodDisruptionBudget{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&networkingv1.NetworkPolicy{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&securityv1beta1.AuthorizationPolicy{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
-		Owns(&pov1.ServiceMonitor{}, builder.WithPredicates(
-			predicate.Not(
-				util.MatchesPredicate[client.Object](hasIgnoreLabel),
-			),
-		)).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
+		Owns(&networkingv1beta1.VirtualService{}).
+		Owns(&securityv1beta1.PeerAuthentication{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(&networkingv1.NetworkPolicy{}).
+		Owns(&securityv1beta1.AuthorizationPolicy{}).
+		Owns(&pov1.ServiceMonitor{}).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(r.SkiperatorOwnedCertRequests)).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)

--- a/controllers/application/controller.go
+++ b/controllers/application/controller.go
@@ -71,7 +71,7 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&securityv1beta1.AuthorizationPolicy{}).
 		Owns(&pov1.ServiceMonitor{}).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(r.SkiperatorOwnedCertRequests)).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Complete(r)
 }
 

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -188,10 +188,15 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 	controllerName := "Deployment"
 	r.SetControllerProgressing(ctx, application, controllerName)
 
-	deployment := appsv1.Deployment{}
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      application.Name,
+			Namespace: application.Namespace,
+		},
+	}
 	deploymentDefinition, err := r.defineDeployment(ctx, application)
 
-	shouldReconcile, err := r.ShouldReconcile(ctx, &deploymentDefinition)
+	shouldReconcile, err := r.ShouldReconcile(ctx, &deployment)
 	if err != nil {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
@@ -202,7 +207,7 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 		return reconcile.Result{}, nil
 	}
 
-	err = r.GetClient().Get(ctx, types.NamespacedName{Name: application.Name, Namespace: application.Namespace}, &deployment)
+	err = r.GetClient().Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			r.EmitNormalEvent(application, "NotFound", fmt.Sprintf("deployment resource for application %s not found, creating deployment", application.Name))

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -197,14 +197,9 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 	deploymentDefinition, err := r.defineDeployment(ctx, application)
 
 	shouldReconcile, err := r.ShouldReconcile(ctx, &deployment)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	err = r.GetClient().Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -191,6 +191,17 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, applica
 	deployment := appsv1.Deployment{}
 	deploymentDefinition, err := r.defineDeployment(ctx, application)
 
+	shouldReconcile, err := r.ShouldReconcile(ctx, &deploymentDefinition)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
+	if !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, nil
+	}
+
 	err = r.GetClient().Get(ctx, types.NamespacedName{Name: application.Name, Namespace: application.Namespace}, &deployment)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -28,7 +28,18 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 		// CreateOrPatch gets the object (from cache) before the mutating function is run, masquerading actual changes
 		// Restoring the Spec from a copy within the mutating func fixes this
 		desiredServiceEntry := serviceEntry.DeepCopy()
-		_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &serviceEntry, func() error {
+
+		shouldReconcile, err := r.ShouldReconcile(ctx, &serviceEntry)
+		if err != nil {
+			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+			return reconcile.Result{}, err
+		}
+
+		if !shouldReconcile {
+			continue
+		}
+
+		_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &serviceEntry, func() error {
 			serviceEntry.Spec = desiredServiceEntry.Spec
 			// Set application as owner of the service entry
 			err := ctrlutil.SetControllerReference(application, &serviceEntry, r.GetScheme())

--- a/controllers/application/egress_service_entry.go
+++ b/controllers/application/egress_service_entry.go
@@ -68,6 +68,16 @@ func (r *ApplicationReconciler) reconcileEgressServiceEntry(ctx context.Context,
 
 	serviceEntriesToDelete := istio.GetServiceEntriesToDelete(serviceEntriesInNamespace.Items, application.Name, serviceEntries)
 	for _, serviceEntry := range serviceEntriesToDelete {
+		shouldReconcile, err := r.ShouldReconcile(ctx, &serviceEntry)
+		if err != nil {
+			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+			return reconcile.Result{}, err
+		}
+
+		if !shouldReconcile {
+			continue
+		}
+
 		err = r.GetClient().Delete(ctx, &serviceEntry)
 		err = client.IgnoreNotFound(err)
 		if err != nil {

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -17,14 +17,9 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 
 	horizontalPodAutoscaler := autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
 	shouldReconcile, err := r.ShouldReconcile(ctx, &horizontalPodAutoscaler)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	if shouldScaleToZero(application.Spec.Replicas) || !skiperatorv1alpha1.IsHPAEnabled(application.Spec.Replicas) {

--- a/controllers/application/horizontal_pod_autoscaler.go
+++ b/controllers/application/horizontal_pod_autoscaler.go
@@ -16,6 +16,17 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 	r.SetControllerProgressing(ctx, application, controllerName)
 
 	horizontalPodAutoscaler := autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
+	shouldReconcile, err := r.ShouldReconcile(ctx, &horizontalPodAutoscaler)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
+	if !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, nil
+	}
+
 	if shouldScaleToZero(application.Spec.Replicas) || !skiperatorv1alpha1.IsHPAEnabled(application.Spec.Replicas) {
 		err := r.GetClient().Delete(ctx, &horizontalPodAutoscaler)
 		err = client.IgnoreNotFound(err)
@@ -27,7 +38,7 @@ func (r *ApplicationReconciler) reconcileHorizontalPodAutoscaler(ctx context.Con
 		return reconcile.Result{}, nil
 	}
 
-	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &horizontalPodAutoscaler, func() error {
+	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &horizontalPodAutoscaler, func() error {
 		// Set application as owner of the horizontal pod autoscaler
 		err := ctrlutil.SetControllerReference(application, &horizontalPodAutoscaler, r.GetScheme())
 		if err != nil {

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -102,6 +102,16 @@ func (r *ApplicationReconciler) reconcileIngressGateway(ctx context.Context, app
 	}
 
 	for _, gateway := range gateways.Items {
+		shouldReconcile, err := r.ShouldReconcile(ctx, gateway)
+		if err != nil {
+			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+			return reconcile.Result{}, err
+		}
+
+		if !shouldReconcile {
+			continue
+		}
+
 		// Skip unrelated gateways
 		if !isIngressGateway(gateway) {
 			continue

--- a/controllers/application/ingress_gateway.go
+++ b/controllers/application/ingress_gateway.go
@@ -134,3 +134,8 @@ func isIngressGateway(gateway *networkingv1beta1.Gateway) bool {
 
 	return match
 }
+
+func hasIgnoreLabel(obj client.Object) bool {
+	labels := obj.GetLabels()
+	return labels["skiperator.kartverket.no/ignore"] == "true"
+}

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -28,6 +28,17 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 	var err error
 
 	if len(application.Spec.Ingresses) > 0 {
+		shouldReconcile, err := r.ShouldReconcile(ctx, &virtualService)
+		if err != nil {
+			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+			return reconcile.Result{}, err
+		}
+
+		if !shouldReconcile {
+			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+			return reconcile.Result{}, nil
+		}
+
 		_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &virtualService, func() error {
 
 			err := ctrlutil.SetControllerReference(application, &virtualService, r.GetScheme())

--- a/controllers/application/ingress_virtual_service.go
+++ b/controllers/application/ingress_virtual_service.go
@@ -29,14 +29,9 @@ func (r *ApplicationReconciler) reconcileIngressVirtualService(ctx context.Conte
 
 	if len(application.Spec.Ingresses) > 0 {
 		shouldReconcile, err := r.ShouldReconcile(ctx, &virtualService)
-		if err != nil {
+		if err != nil || !shouldReconcile {
 			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 			return reconcile.Result{}, err
-		}
-
-		if !shouldReconcile {
-			r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-			return reconcile.Result{}, nil
 		}
 
 		_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &virtualService, func() error {

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -30,6 +30,17 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 		},
 	}
 
+	shouldReconcile, err := r.ShouldReconcile(ctx, &networkPolicy)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
+	if !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, nil
+	}
+
 	netpolSpec := networking.CreateNetPolSpec(
 		networking.NetPolOpts{
 			AccessPolicy:     application.Spec.AccessPolicy,

--- a/controllers/application/network_policy.go
+++ b/controllers/application/network_policy.go
@@ -31,14 +31,9 @@ func (r *ApplicationReconciler) reconcileNetworkPolicy(ctx context.Context, appl
 	}
 
 	shouldReconcile, err := r.ShouldReconcile(ctx, &networkPolicy)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	netpolSpec := networking.CreateNetPolSpec(

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -18,14 +18,9 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 
 	peerAuthentication := securityv1beta1.PeerAuthentication{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
 	shouldReconcile, err := r.ShouldReconcile(ctx, &peerAuthentication)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &peerAuthentication, func() error {

--- a/controllers/application/peer_authentication.go
+++ b/controllers/application/peer_authentication.go
@@ -17,7 +17,18 @@ func (r *ApplicationReconciler) reconcilePeerAuthentication(ctx context.Context,
 	r.SetControllerProgressing(ctx, application, controllerName)
 
 	peerAuthentication := securityv1beta1.PeerAuthentication{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
-	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &peerAuthentication, func() error {
+	shouldReconcile, err := r.ShouldReconcile(ctx, &peerAuthentication)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
+	if !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, nil
+	}
+
+	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &peerAuthentication, func() error {
 		// Set application as owner of the peer authentication
 		err := ctrlutil.SetControllerReference(application, &peerAuthentication, r.GetScheme())
 		if err != nil {

--- a/controllers/application/pod_disruption_budget.go
+++ b/controllers/application/pod_disruption_budget.go
@@ -17,6 +17,16 @@ func (r *ApplicationReconciler) reconcilePodDisruptionBudget(ctx context.Context
 	_, _ = r.SetControllerProgressing(ctx, application, controllerName)
 
 	pdb := policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
+	shouldReconcile, err := r.ShouldReconcile(ctx, &pdb)
+	if err != nil {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
+	}
+
+	if !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, nil
+	}
 
 	if *application.Spec.EnablePDB {
 		_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &pdb, func() error {

--- a/controllers/application/pod_disruption_budget.go
+++ b/controllers/application/pod_disruption_budget.go
@@ -18,14 +18,9 @@ func (r *ApplicationReconciler) reconcilePodDisruptionBudget(ctx context.Context
 
 	pdb := policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
 	shouldReconcile, err := r.ShouldReconcile(ctx, &pdb)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	if *application.Spec.EnablePDB {

--- a/controllers/application/service.go
+++ b/controllers/application/service.go
@@ -25,14 +25,9 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, applicatio
 
 	service := corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
 	shouldReconcile, err := r.ShouldReconcile(ctx, &service)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &service, func() error {

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -16,13 +16,11 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 	r.SetControllerProgressing(ctx, application, controllerName)
 
 	serviceAccount := corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
-	shouldReconcile, err := r.ShouldReconcile(ctx, &serviceAccount)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
 
-	if !shouldReconcile {
-		return reconcile.Result{}, nil
+	shouldReconcile, err := r.ShouldReconcile(ctx, &serviceAccount)
+	if err != nil || !shouldReconcile {
+		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
+		return reconcile.Result{}, err
 	}
 
 	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &serviceAccount, func() error {

--- a/controllers/application/service_account.go
+++ b/controllers/application/service_account.go
@@ -16,7 +16,16 @@ func (r *ApplicationReconciler) reconcileServiceAccount(ctx context.Context, app
 	r.SetControllerProgressing(ctx, application, controllerName)
 
 	serviceAccount := corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: application.Name}}
-	_, err := ctrlutil.CreateOrPatch(ctx, r.GetClient(), &serviceAccount, func() error {
+	shouldReconcile, err := r.ShouldReconcile(ctx, &serviceAccount)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if !shouldReconcile {
+		return reconcile.Result{}, nil
+	}
+
+	_, err = ctrlutil.CreateOrPatch(ctx, r.GetClient(), &serviceAccount, func() error {
 		// Set application as owner of the sidecar
 		err := ctrlutil.SetControllerReference(application, &serviceAccount, r.GetScheme())
 		if err != nil {

--- a/controllers/application/service_monitor.go
+++ b/controllers/application/service_monitor.go
@@ -27,14 +27,9 @@ func (r *ApplicationReconciler) reconcileServiceMonitor(ctx context.Context, app
 	}}
 
 	shouldReconcile, err := r.ShouldReconcile(ctx, &serviceMonitor)
-	if err != nil {
+	if err != nil || !shouldReconcile {
 		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
 		return reconcile.Result{}, err
-	}
-
-	if !shouldReconcile {
-		r.SetControllerFinishedOutcome(ctx, application, controllerName, err)
-		return reconcile.Result{}, nil
 	}
 
 	if application.Spec.Prometheus == nil {

--- a/pkg/resourcegenerator/istio/service_entry.go
+++ b/pkg/resourcegenerator/istio/service_entry.go
@@ -64,6 +64,7 @@ func GetServiceEntriesToDelete(serviceEntriesInNamespace []*networkingv1beta1.Se
 	var serviceEntriesToDelete []networkingv1beta1.ServiceEntry
 
 	for _, serviceEntry := range serviceEntriesInNamespace {
+
 		ownerIndex := slices.IndexFunc(serviceEntry.GetOwnerReferences(), func(ownerReference metav1.OwnerReference) bool {
 			return ownerReference.Name == ownerName
 		})

--- a/pkg/util/reconciler.go
+++ b/pkg/util/reconciler.go
@@ -125,6 +125,24 @@ func (r *ReconcilerBase) IsIstioEnabledForNamespace(ctx context.Context, namespa
 	return exists
 }
 
+func hasIgnoreLabel(obj client.Object) bool {
+	labels := obj.GetLabels()
+	return labels["skiperator.kartverket.no/ignore"] == "true"
+}
+
+func (r *ReconcilerBase) ShouldReconcile(ctx context.Context, obj client.Object) (bool, error) {
+	err := r.GetClient().Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	err = client.IgnoreNotFound(err)
+
+	if err != nil {
+		return false, err
+	}
+
+	shouldReconcile := !hasIgnoreLabel(obj)
+
+	return shouldReconcile, nil
+}
+
 func (r *ReconcilerBase) EmitWarningEvent(object runtime.Object, reason string, message string) {
 	r.GetRecorder().Event(
 		object,

--- a/tests/application/ignore-reconcile/00-application.yaml
+++ b/tests/application/ignore-reconcile/00-application.yaml
@@ -1,0 +1,9 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: ignore-reconcile
+spec:
+  image: image
+  port: 8080
+  ingresses:
+    - example.com

--- a/tests/application/ignore-reconcile/00-assert.yaml
+++ b/tests/application/ignore-reconcile/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+   name: ignore-reconcile-ingress
+spec:
+  hosts:
+    - example.com

--- a/tests/application/ignore-reconcile/01-assert.yaml
+++ b/tests/application/ignore-reconcile/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ignore-reconcile-ingress
+  labels:
+    skiperator.kartverket.no/ignore: "true"

--- a/tests/application/ignore-reconcile/01-virtualservice-set-label.yaml
+++ b/tests/application/ignore-reconcile/01-virtualservice-set-label.yaml
@@ -1,0 +1,8 @@
+# Testing with a VirtualService, but any reconciled object would do
+
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ignore-reconcile-ingress
+  labels:
+    skiperator.kartverket.no/ignore: "true"

--- a/tests/application/ignore-reconcile/02-application-change-ingress.yaml
+++ b/tests/application/ignore-reconcile/02-application-change-ingress.yaml
@@ -1,0 +1,9 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: ignore-reconcile
+spec:
+  image: image
+  port: 8080
+  ingresses:
+    - test.com

--- a/tests/application/ignore-reconcile/02-assert.yaml
+++ b/tests/application/ignore-reconcile/02-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ignore-reconcile-ingress
+spec:
+  hosts:
+    - example.com

--- a/tests/application/ignore-reconcile/02-errors.yaml
+++ b/tests/application/ignore-reconcile/02-errors.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ignore-reconcile-ingress
+spec:
+  hosts:
+    - test.com

--- a/tests/application/ignore-reconcile/03-assert.yaml
+++ b/tests/application/ignore-reconcile/03-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ignore-reconcile-ingress
+  labels:
+    skiperator.kartverket.no/ignore: "false"
+spec:
+  hosts:
+    - test.com

--- a/tests/application/ignore-reconcile/03-virtualservice-remove-label.yaml
+++ b/tests/application/ignore-reconcile/03-virtualservice-remove-label.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: ignore-reconcile-ingress
+  labels:
+    skiperator.kartverket.no/ignore: "false"

--- a/tests/application/ignore-reconcile/04-delete-application.yaml
+++ b/tests/application/ignore-reconcile/04-delete-application.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: skiperator.kartverket.no/v1alpha1
+    kind: Application
+    name: ignore-reconcile
+


### PR DESCRIPTION
In some cases it may be necessary to manually edit child resources of an application. This is usually in the short term in terms of debugging a problem or when implementing a temporary workaround. In this case we need the latter and instead of migrating the team out of their skiperator app we add a feature here to allow us to edit the Gateway resource temporarily.

This PR adds a feature where you can manually label a child with `skiperator.kartverket.no/ignore: "true"` to opt that resource out of reconciliation. When you are done with that resource, you simply remove the label. Note that this is not something you can do via `resourceLabels`, as skiperator will add the label but because of the resource then being opted out of reconcile it will not remove the label.

I forsee this feature as a SKIP-team feature where we will mostly use it ourselves, perhaps even blocking the teams from setting this label.