### PR TITLE
Allow updating container for cron jobs

### DIFF
--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -42,7 +42,7 @@ type SKIPJobList struct {
 // SKIPJobSpec defines the desired state of SKIPJob
 //
 // A SKIPJob is either defined as a one-off or a scheduled job. If the Cron field is set for SKIPJob, it may not be removed. If the Cron field is unset, it may not be added.
-// The Container settings of a SKIPJob is also immutable, and may not be changed after creating a SKIPJob.
+// The Container field of a SKIPJob is only mutable if the Cron field is set. If unset, you must delete your SKIPJob to change container settings.
 //
 // +kubebuilder:validation:XValidation:rule="(has(oldSelf.cron) && has(self.cron)) || (!has(oldSelf.cron) && !has(self.cron))", message="After creation of a SKIPJob you may not remove the Cron field if it was previously present, or add it if it was previously omitted. Please delete the SKIPJob to change its nature from a one-off/scheduled job."
 // +kubebuilder:validation:XValidation:rule="((!has(self.cron) && (oldSelf.container == self.container)) || has(self.cron))", message="The field Container is immutable for one-off jobs. Please delete your SKIPJob to change the containers settings."

--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -45,6 +45,7 @@ type SKIPJobList struct {
 // The Container settings of a SKIPJob is also immutable, and may not be changed after creating a SKIPJob.
 //
 // +kubebuilder:validation:XValidation:rule="(has(oldSelf.cron) && has(self.cron)) || (!has(oldSelf.cron) && !has(self.cron))", message="After creation of a SKIPJob you may not remove the Cron field if it was previously present, or add it if it was previously omitted. Please delete the SKIPJob to change its nature from a one-off/scheduled job."
+// +kubebuilder:validation:XValidation:rule="((!has(self.cron) && (oldSelf.container == self.container)) || has(self.cron))", message="The field Container is immutable for one-off jobs. Please delete your SKIPJob to change the containers settings."
 // +kubebuilder:object:generate=true
 type SKIPJobSpec struct {
 	// Settings for the actual Job. If you use a scheduled job, the settings in here will also specify the template of the job.
@@ -60,7 +61,6 @@ type SKIPJobSpec struct {
 	// Settings for the Pods running in the job. Fields are mostly the same as an Application, and are (probably) better documented there. Some fields are omitted, but none added.
 	// Once set, you may not change Container without deleting your current SKIPJob
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="The field Container is immutable. Please delete your SKIPJob to change the containers settings."
 	// +kubebuilder:validation:Required
 	Container ContainerSettings `json:"container"`
 }

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -587,10 +587,6 @@ spec:
                 required:
                 - image
                 type: object
-                x-kubernetes-validations:
-                - message: The field Container is immutable. Please delete your SKIPJob
-                    to change the containers settings.
-                  rule: self == oldSelf
               cron:
                 description: Settings for the Job if you are running a scheduled job.
                   Optional as Jobs may be one-off.
@@ -668,6 +664,10 @@ spec:
                 job.
               rule: (has(oldSelf.cron) && has(self.cron)) || (!has(oldSelf.cron) &&
                 !has(self.cron))
+            - message: The field Container is immutable for one-off jobs. Please delete
+                your SKIPJob to change the containers settings.
+              rule: ((!has(self.cron) && (oldSelf.container == self.container)) ||
+                has(self.cron))
           status:
             description: SKIPJobStatus defines the observed state of SKIPJob
             properties:

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -35,8 +35,9 @@ spec:
             description: "SKIPJobSpec defines the desired state of SKIPJob \n A SKIPJob
               is either defined as a one-off or a scheduled job. If the Cron field
               is set for SKIPJob, it may not be removed. If the Cron field is unset,
-              it may not be added. The Container settings of a SKIPJob is also immutable,
-              and may not be changed after creating a SKIPJob."
+              it may not be added. The Container field of a SKIPJob is only mutable
+              if the Cron field is set. If unset, you must delete your SKIPJob to
+              change container settings."
             properties:
               container:
                 description: Settings for the Pods running in the job. Fields are


### PR DESCRIPTION
Updating the container settings for Cron jobs makes sense, as a product team might want to change the behaviour of a job between runs (for example an updated image). It is still not allowed to update the container settings for a one-off job.