### PR TITLE
Set UnhealthyPodEviction to AlwaysAllow

### DIFF
--- a/controllers/application/pod_disruption_budget.go
+++ b/controllers/application/pod_disruption_budget.go
@@ -53,7 +53,8 @@ func (r *ApplicationReconciler) reconcilePodDisruptionBudget(ctx context.Context
 				Selector: &metav1.LabelSelector{
 					MatchLabels: util.GetPodAppSelector(application.Name),
 				},
-				MinAvailable: determineMinAvailable(minReplicas),
+				MinAvailable:               determineMinAvailable(minReplicas),
+				UnhealthyPodEvictionPolicy: util.PointTo(policyv1.AlwaysAllow),
 			}
 
 			return nil


### PR DESCRIPTION
Enabled i kubernetes 1.27, but supported in 1.26 spec.

From the kubernetes docs:
> It is recommended to set AlwaysAllow [Unhealthy Pod Eviction Policy](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy) to your PodDisruptionBudgets to support eviction of misbehaving applications during a node drain. The default behavior is to wait for the application pods to become [healthy](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod) before the drain can proceed.