### PR TITLE
Do not add gcp env var to skipjob spec, make copy instead

### DIFF
--- a/controllers/skipjob/job.go
+++ b/controllers/skipjob/job.go
@@ -344,16 +344,6 @@ func getJobSpec(skipJob *skiperatorv1alpha1.SKIPJob, selector *metav1.LabelSelec
 	return jobSpec
 }
 
-func hasGCPEnvVar(env []corev1.EnvVar) bool {
-	for _, env := range env {
-		if env.Name == "GOOGLE_APPLICATION_CREDENTIALS" {
-			return true
-		}
-	}
-
-	return false
-}
-
 func generateDebugContainer(pod *corev1.Pod) (*corev1.Pod, *corev1.EphemeralContainer, error) {
 	ec := &corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{

--- a/pkg/resourcegenerator/core/pod.go
+++ b/pkg/resourcegenerator/core/pod.go
@@ -66,7 +66,7 @@ func CreateApplicationContainer(application *skiperatorv1alpha1.Application, opt
 	}
 }
 
-func CreateJobContainer(skipJob *skiperatorv1alpha1.SKIPJob, volumeMounts []corev1.VolumeMount) corev1.Container {
+func CreateJobContainer(skipJob *skiperatorv1alpha1.SKIPJob, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar) corev1.Container {
 	return corev1.Container{
 		Name:                     skipJob.KindPostFixedName(),
 		Image:                    skipJob.Spec.Container.Image,
@@ -75,7 +75,7 @@ func CreateJobContainer(skipJob *skiperatorv1alpha1.SKIPJob, volumeMounts []core
 		SecurityContext:          &util.LeastPrivilegeContainerSecurityContext,
 		EnvFrom:                  getEnvFrom(skipJob.Spec.Container.EnvFrom),
 		Resources:                getResourceRequirements(skipJob.Spec.Container.Resources),
-		Env:                      skipJob.Spec.Container.Env,
+		Env:                      envVars,
 		ReadinessProbe:           getProbe(skipJob.Spec.Container.Readiness),
 		LivenessProbe:            getProbe(skipJob.Spec.Container.Liveness),
 		StartupProbe:             getProbe(skipJob.Spec.Container.Startup),


### PR DESCRIPTION
After allowing editing of `spec.container` if `spec.cron` was set, it seems we allowed a lurking bug which updated the SKIPJob spec with the GCP env for every reconcile loop, and updating the spec caused another reconcile loop which again added a new GCP env to the spec.

With this change it is never added to the spec of the SKIPJob, a copy is used instead.