### PR TITLE
Add more permissions for proxy, so frontends can run

### DIFF
--- a/pkg/resourcegenerator/core/pod.go
+++ b/pkg/resourcegenerator/core/pod.go
@@ -61,6 +61,9 @@ func CreateApplicationContainer(application *skiperatorv1alpha1.Application, opt
 			RunAsGroup:               util.PointTo(util.SkiperatorUser),
 			RunAsNonRoot:             util.PointTo(true),
 			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{
+					"NET_BIND_SERVICE",
+				},
 				Drop: []corev1.Capability{"ALL"},
 			},
 		},

--- a/tests/application/minimal/application-assert.yaml
+++ b/tests/application/minimal/application-assert.yaml
@@ -38,6 +38,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+              add:
+                - NET_BIND_SERVICE
           volumeMounts:
             - mountPath: /tmp
               name: tmp


### PR DESCRIPTION
The Caddy dockerfile sets the net_bind_service capability, so even if we don't really require it for our usecase, the docker image requires it to run. Without it many frontends will not work.