### PR TITLE
application: add 'team' to spec

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -78,6 +78,12 @@ type ApplicationSpec struct {
 	//+kubebuilder:default=medium
 	Priority string `json:"priority,omitempty"`
 
+	// Team specifies the team who owns this particular app.
+	// Usually sourced from the namespace label.
+	//
+	//+kubebuilder:validation:Optional
+	Team string `json:"team,omitempty"`
+
 	// Override the command set in the Dockerfile. Usually only used when debugging
 	// or running third-party containers where you don't have control over the Dockerfile
 	//

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -734,6 +734,10 @@ spec:
                     - Recreate
                     type: string
                 type: object
+              team:
+                description: Team specifies the team who owns this particular app.
+                  Usually sourced from the namespace label.
+                type: string
             required:
             - image
             - port

--- a/controllers/application/deployment.go
+++ b/controllers/application/deployment.go
@@ -81,7 +81,12 @@ func (r *ApplicationReconciler) defineDeployment(ctx context.Context, applicatio
 
 	skiperatorContainer.VolumeMounts = containerVolumeMounts
 
-	labels := util.GetPodAppSelector(application.Name)
+	var labels map[string]string
+	if len(application.Spec.Team) > 0 {
+		labels = util.GetPodAppAndTeamSelector(application.Name, application.Spec.Team)
+	} else {
+		labels = util.GetPodAppSelector(application.Name)
+	}
 
 	generatedSpecAnnotations := map[string]string{
 		"argocd.argoproj.io/sync-options": "Prune=false",

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -85,6 +85,13 @@ func GetPodAppSelector(applicationName string) map[string]string {
 	return map[string]string{"app": applicationName}
 }
 
+func GetPodAppAndTeamSelector(applicationName string, teamName string) map[string]string {
+	return map[string]string{
+		"app":  applicationName,
+		"team": teamName,
+	}
+}
+
 func HasUpperCaseLetter(word string) bool {
 	for _, letter := range word {
 		if unicode.IsUpper(letter) {

--- a/tests/application/team-label/application-assert.yaml
+++ b/tests/application/team-label/application-assert.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: chainsaw-team-label
+  name: team-label
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: chainsaw-team-label
+  name: team-label
+  annotations:
+    argocd.argoproj.io/sync-options: "Prune=false"
+spec:
+  selector:
+    matchLabels:
+      app: team-label
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        argocd.argoproj.io/sync-options: "Prune=false"
+      labels:
+        app: team-label
+        team: some-team
+    spec:
+      containers:
+        - name: team-label
+          image: image
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 150
+            runAsUser: 150
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      imagePullSecrets:
+        - name: github-auth
+      securityContext:
+        fsGroup: 150
+        supplementalGroups:
+          - 150
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: team-label
+      volumes:
+        - emptyDir: {}
+          name: tmp
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  namespace: chainsaw-team-label
+  name: team-label
+spec:
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: team-label
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: chainsaw-team-label
+  name: team-label
+spec:
+  selector:
+    app: team-label
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+      appProtocol: http
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  namespace: chainsaw-team-label
+  name: team-label
+spec:
+  selector:
+    matchLabels:
+      app: team-label
+  mtls:
+    mode: STRICT

--- a/tests/application/team-label/application-no-team-assert.yaml
+++ b/tests/application/team-label/application-no-team-assert.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: chainsaw-no-team-label
+  name: team-label-missing
+  annotations:
+    argocd.argoproj.io/sync-options: "Prune=false"
+spec:
+  selector:
+    matchLabels:
+      app: team-label-missing
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        argocd.argoproj.io/sync-options: "Prune=false"
+      labels:
+        app: team-label-missing
+    spec:
+      containers:
+        - name: team-label-missing
+          image: image
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 150
+            runAsUser: 150
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      imagePullSecrets:
+        - name: github-auth
+      securityContext:
+        fsGroup: 150
+        supplementalGroups:
+          - 150
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: team-label-missing
+      volumes:
+        - emptyDir: {}
+          name: tmp

--- a/tests/application/team-label/application-no-team-error-assert.yaml
+++ b/tests/application/team-label/application-no-team-error-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: chainsaw-no-team-label
+  name: team-label-missing
+spec:
+  selector:
+    matchLabels:
+      app: team-label-missing
+  template:
+    metadata:
+      labels:
+        app: team-label-missing
+        team: some-team

--- a/tests/application/team-label/application-no-team.yaml
+++ b/tests/application/team-label/application-no-team.yaml
@@ -1,0 +1,8 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: team-label-missing
+  namespace: chainsaw-no-team-label
+spec:
+  image: image
+  port: 8080

--- a/tests/application/team-label/application-with-fixed-team-assert.yaml
+++ b/tests/application/team-label/application-with-fixed-team-assert.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: chainsaw-team-label
+  name: team-label-fixed
+  annotations:
+    argocd.argoproj.io/sync-options: "Prune=false"
+spec:
+  selector:
+    matchLabels:
+      app: team-label-fixed
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        argocd.argoproj.io/sync-options: "Prune=false"
+      labels:
+        app: team-label-fixed
+        team: other-team
+    spec:
+      containers:
+        - name: team-label-fixed
+          image: image
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 150
+            runAsUser: 150
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      imagePullSecrets:
+        - name: github-auth
+      securityContext:
+        fsGroup: 150
+        supplementalGroups:
+          - 150
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: team-label-fixed
+      volumes:
+        - emptyDir: {}
+          name: tmp

--- a/tests/application/team-label/application-with-fixed-team.yaml
+++ b/tests/application/team-label/application-with-fixed-team.yaml
@@ -1,0 +1,9 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: team-label-fixed
+  namespace: chainsaw-team-label
+spec:
+  image: image
+  port: 8080
+  team: other-team

--- a/tests/application/team-label/application.yaml
+++ b/tests/application/team-label/application.yaml
@@ -1,0 +1,8 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: team-label
+  namespace: chainsaw-team-label
+spec:
+  image: image
+  port: 8080

--- a/tests/application/team-label/chainsaw-test.yaml
+++ b/tests/application/team-label/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: team-label
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  steps:
+    - try:
+        - create:
+            file: namespace.yaml
+        - create:
+            file: application.yaml
+        - assert:
+            file: application-assert.yaml
+    - try:
+        - create:
+            file: application-with-fixed-team.yaml
+        - assert:
+            file: application-with-fixed-team-assert.yaml

--- a/tests/application/team-label/chainsaw-test.yaml
+++ b/tests/application/team-label/chainsaw-test.yaml
@@ -19,3 +19,12 @@ spec:
             file: application-with-fixed-team.yaml
         - assert:
             file: application-with-fixed-team-assert.yaml
+    - try:
+        - create:
+            file: namespace-no-team.yaml
+        - create:
+            file: application-no-team.yaml
+        - assert:
+            file: application-no-team-assert.yaml
+        - error:
+            file: application-no-team-error-assert.yaml

--- a/tests/application/team-label/namespace-no-team.yaml
+++ b/tests/application/team-label/namespace-no-team.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-no-team-label

--- a/tests/application/team-label/namespace.yaml
+++ b/tests/application/team-label/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    team: some-team
+  name: chainsaw-team-label


### PR DESCRIPTION
In order to propagate team name down to running Pod's this field needs to be explicitly set or inferred from the Application's namespace.