### PR TITLE
Use correct labelselector for skipjob pods in netpol

### DIFF
--- a/api/v1alpha1/podtypes/access_policy.go
+++ b/api/v1alpha1/podtypes/access_policy.go
@@ -63,7 +63,8 @@ type OutboundPolicy struct {
 //
 // +kubebuilder:object:generate=true
 type InternalRule struct {
-	// The name of the Application you are allowing traffic to/from.
+	// The name of the Application you are allowing traffic to/from. If you wish to allow traffic from a SKIPJob, this field should
+	// be suffixed with -skipjob
 	//
 	//+kubebuilder:validation:Required
 	Application string `json:"application"`

--- a/controllers/skipjob/network_policy.go
+++ b/controllers/skipjob/network_policy.go
@@ -27,7 +27,7 @@ func (r *SKIPJobReconciler) reconcileNetworkPolicy(ctx context.Context, skipJob 
 		AccessPolicy:    skipJob.Spec.Container.AccessPolicy,
 		Namespace:       skipJob.Namespace,
 		Namespaces:      &namespaces,
-		Name:            skipJob.Name,
+		Name:            skipJob.KindPostFixedName(),
 		RelatedServices: &egressServices,
 	}
 

--- a/tests/skipjob/access-policy-job/skipjob-assert.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-assert.yaml
@@ -16,7 +16,7 @@ spec:
               app: minimal-application
   podSelector:
     matchLabels:
-      app: access-policy-job
+      app: access-policy-job-skipjob
   policyTypes:
     - Egress
 ---


### PR DESCRIPTION
Uses the correct labelSelector for SKIPJobs, as the Pods are labeled with `app: nameOfSKIPJob-skipjob`.

Also adds a little line regarding accessPolicy names for SKIPJobs