### PR TITLE
Introduce anti-affinity

### DIFF
--- a/api/v1alpha1/podtypes/pod_settings.go
+++ b/api/v1alpha1/podtypes/pod_settings.go
@@ -15,4 +15,11 @@ type PodSettings struct {
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=30
 	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
+	// DisablePodSpreadTopologyConstraints specifies whether to disable the addition of Pod Topology Spread Constraints to
+	// a given pod.
+	//
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:=false
+	DisablePodSpreadTopologyConstraints bool `json:"disablePodSpreadTopologyConstraints,omitempty"`
 }

--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/kartverket/skiperator/pkg/flags"
 	"github.com/kartverket/skiperator/pkg/k8sfeatures"
 	"github.com/kartverket/skiperator/pkg/util"
 	"k8s.io/client-go/discovery"
@@ -135,6 +136,11 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+
+	if flags.FeatureFlags == nil {
+		panic("something is wrong with the go runtime, panicing")
+	}
+	setupLog.Info("initializing skiperator with feature flags", "features", flags.FeatureFlags)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -738,6 +738,12 @@ spec:
                       These annotations can for example be used to change the behaviour
                       of sidecars and similar.
                     type: object
+                  disablePodSpreadTopologyConstraints:
+                    default: false
+                    description: |-
+                      DisablePodSpreadTopologyConstraints specifies whether to disable the addition of Pod Topology Spread Constraints to
+                      a given pod.
+                    type: boolean
                   terminationGracePeriodSeconds:
                     default: 30
                     description: |-

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -474,6 +474,12 @@ spec:
                           These annotations can for example be used to change the
                           behaviour of sidecars and similar.
                         type: object
+                      disablePodSpreadTopologyConstraints:
+                        default: false
+                        description: |-
+                          DisablePodSpreadTopologyConstraints specifies whether to disable the addition of Pod Topology Spread Constraints to
+                          a given pod.
+                        type: boolean
                       terminationGracePeriodSeconds:
                         default: 30
                         description: |-

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,0 +1,39 @@
+package flags
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const envPrefix = "SKIPERATOR"
+
+var FeatureFlags *Features
+
+// Features contains various Skiperator knobs which can be enabled/disabled runtime with
+// environment variables.
+type Features struct {
+	DisablePodTopologySpreadConstraints bool
+}
+
+func init() {
+	FeatureFlags = &Features{
+		DisablePodTopologySpreadConstraints: getEnvWithFallback("DISABLE_PTSC", false),
+	}
+}
+
+func getEnvWithFallback(name string, defaultValue bool) bool {
+	key := fmt.Sprintf("%s_%s", envPrefix, name)
+
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return defaultValue
+	}
+
+	return v
+}

--- a/pkg/resourcegenerator/core/constants.go
+++ b/pkg/resourcegenerator/core/constants.go
@@ -1,0 +1,12 @@
+package core
+
+// Based on https://kubernetes.io/docs/reference/labels-annotations-taints/
+
+type SkiperatorTopologyKey string
+
+const (
+	// Hostname is the value populated by the Kubelet.
+	Hostname SkiperatorTopologyKey = "kubernetes.io/hostname"
+	// OnPremFailureDomain is populated to the underlying ESXi hostname by the GKE on VMware tooling.
+	OnPremFailureDomain SkiperatorTopologyKey = "onprem.gke.io/failure-domain-name"
+)

--- a/pkg/resourcegenerator/core/pod.go
+++ b/pkg/resourcegenerator/core/pod.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
+	"github.com/kartverket/skiperator/pkg/flags"
 	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,10 +47,14 @@ func CreatePodSpec(container corev1.Container, volumes []corev1.Volume, serviceA
 		PriorityClassName: fmt.Sprintf("skip-%s", priority),
 	}
 
-	if !podSettings.DisablePodSpreadTopologyConstraints {
-		p.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
-			spreadConstraintForAppAndKey(container.Name, Hostname),
-			spreadConstraintForAppAndKey(container.Name, OnPremFailureDomain),
+	// Global feature flag
+	if !flags.FeatureFlags.DisablePodTopologySpreadConstraints {
+		// Allow override per application
+		if !podSettings.DisablePodSpreadTopologyConstraints {
+			p.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+				spreadConstraintForAppAndKey(container.Name, Hostname),
+				spreadConstraintForAppAndKey(container.Name, OnPremFailureDomain),
+			}
 		}
 	}
 

--- a/pkg/resourcegenerator/core/pod.go
+++ b/pkg/resourcegenerator/core/pod.go
@@ -231,5 +231,8 @@ func spreadConstraintForAppAndKey(appName string, key SkiperatorTopologyKey) cor
 				},
 			},
 		},
+		// Beta from K8s 1.27, enabled by default
+		// See https://medium.com/wise-engineering/avoiding-kubernetes-pod-topology-spread-constraint-pitfalls-d369bb04689e
+		MatchLabelKeys: []string{"pod-template-hash"},
 	}
 }

--- a/pkg/util/reconciler.go
+++ b/pkg/util/reconciler.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"github.com/kartverket/skiperator/pkg/flags"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
@@ -32,6 +33,7 @@ type ReconcilerBase struct {
 	scheme           *runtime.Scheme
 	restConfig       *rest.Config
 	recorder         record.EventRecorder
+	features         *flags.Features
 }
 
 func NewReconcilerBase(client client.Client, extensionsClient *apiextensionsclient.Clientset, scheme *runtime.Scheme, restConfig *rest.Config, recorder record.EventRecorder, apireader client.Reader) ReconcilerBase {
@@ -42,6 +44,7 @@ func NewReconcilerBase(client client.Client, extensionsClient *apiextensionsclie
 		scheme:           scheme,
 		restConfig:       restConfig,
 		recorder:         recorder,
+		features:         flags.FeatureFlags,
 	}
 }
 

--- a/tests/application/minimal/application-assert.yaml
+++ b/tests/application/minimal/application-assert.yaml
@@ -56,6 +56,27 @@ spec:
       volumes:
         - emptyDir: {}
           name: tmp
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - minimal
+                topologyKey: "kubernetes.io/hostname"
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - minimal
+                topologyKey: "onprem.gke.io/failure-domain-name"
+              weight: 100
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/tests/application/minimal/application-assert.yaml
+++ b/tests/application/minimal/application-assert.yaml
@@ -66,6 +66,8 @@ spec:
                 operator: In
                 values:
                   - minimal
+          matchLabelKeys:
+            - pod-template-hash
         - maxSkew: 1
           topologyKey: "onprem.gke.io/failure-domain-name"
           whenUnsatisfiable: ScheduleAnyway
@@ -75,6 +77,8 @@ spec:
                 operator: In
                 values:
                   - minimal
+          matchLabelKeys:
+            - pod-template-hash
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/tests/application/minimal/application-assert.yaml
+++ b/tests/application/minimal/application-assert.yaml
@@ -56,27 +56,25 @@ spec:
       volumes:
         - emptyDir: {}
           name: tmp
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - minimal
-                topologyKey: "kubernetes.io/hostname"
-              weight: 100
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - minimal
-                topologyKey: "onprem.gke.io/failure-domain-name"
-              weight: 100
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - minimal
+        - maxSkew: 1
+          topologyKey: "onprem.gke.io/failure-domain-name"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - minimal
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
This is an implementation of anti-affinity rules based on hostname and VMware ESXi host labels (if present). It's currently implemented using [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) but can be switched to using regular (anti-)affinity rules.