### PR TITLE
Fix missing security context for cloudsql proxy

### DIFF
--- a/pkg/resourcegenerator/core/pod.go
+++ b/pkg/resourcegenerator/core/pod.go
@@ -115,6 +115,12 @@ func CreateCloudSqlProxyContainer(cs podtypes.CloudSQLProxySettings) corev1.Cont
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: "RuntimeDefault",
 			},
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{
+					"NET_BIND_SERVICE",
+				},
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/tests/application/cloudsql-auth-proxy/application-assert.yaml
+++ b/tests/application/cloudsql-auth-proxy/application-assert.yaml
@@ -62,6 +62,11 @@ spec:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: "RuntimeDefault"
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
           resources:
             requests:
               memory: "64Mi"


### PR DESCRIPTION
PSA: Restricted stops the pod from working without this