### PR TITLE
Missing status when updating to new CRD blocks resource update

### DIFF
--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -39,7 +39,7 @@ type SKIPJobStatus struct {
 // A SKIPJob is either defined as a one-off or a scheduled job. If the Cron field is set for SKIPJob, it may not be removed. If the Cron field is unset, it may not be added.
 // The Container field of a SKIPJob is only mutable if the Cron field is set. If unset, you must delete your SKIPJob to change container settings.
 // +kubebuilder:validation:XValidation:rule="(has(oldSelf.spec.cron) && has(self.spec.cron)) || (!has(oldSelf.spec.cron) && !has(self.spec.cron))", message="After creation of a SKIPJob you may not remove the Cron field if it was previously present, or add it if it was previously omitted. Please delete the SKIPJob to change its nature from a one-off/scheduled job."
-// +kubebuilder:validation:XValidation:rule="(!has(self.status) || ((!has(self.spec.cron) && (oldSelf.spec.container == self.spec.container)) || has(self.spec.cron)))", message="The field Container is immutable for one-off jobs. Please delete your SKIPJob to change the containers settings."
+// +kubebuilder:validation:XValidation:rule="(size(self.status.subresources) == 0|| ((!has(self.spec.cron) && (oldSelf.spec.container == self.spec.container)) || has(self.spec.cron)))", message="The field Container is immutable for one-off jobs. Please delete your SKIPJob to change the containers settings."
 // SKIPJob is the Schema for the skipjobs API
 type SKIPJob struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -981,7 +981,7 @@ spec:
             && !has(self.spec.cron))
         - message: The field Container is immutable for one-off jobs. Please delete
             your SKIPJob to change the containers settings.
-          rule: (!has(self.status) || ((!has(self.spec.cron) && (oldSelf.spec.container
+          rule: (size(self.status.subresources) == 0|| ((!has(self.spec.cron) && (oldSelf.spec.container
             == self.spec.container)) || has(self.spec.cron)))
     served: true
     storage: true

--- a/internal/controllers/common/util_test.go
+++ b/internal/controllers/common/util_test.go
@@ -4,7 +4,9 @@ import (
 	"github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/testutil"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+	"time"
 )
 
 func TestShouldReconcile(t *testing.T) {
@@ -13,4 +15,46 @@ func TestShouldReconcile(t *testing.T) {
 	assert.True(t, ShouldReconcile(app))
 	app.Labels["skiperator.kartverket.no/ignore"] = "true"
 	assert.False(t, ShouldReconcile(app))
+}
+
+func TestStatusDiffWithTimestamp(t *testing.T) {
+	status := &v1alpha1.SkiperatorStatus{
+		Summary: v1alpha1.Status{
+			Status:    v1alpha1.SYNCED,
+			Message:   "All subresources synced",
+			TimeStamp: time.Now().String(),
+		},
+		Conditions: []v1.Condition{
+			{
+				ObservedGeneration: 1,
+				LastTransitionTime: v1.Now(),
+			},
+		},
+		SubResources: map[string]v1alpha1.Status{
+			"test": {
+				Status:    v1alpha1.SYNCED,
+				Message:   "All subresources synced",
+				TimeStamp: time.Now().String(),
+			},
+		},
+	}
+
+	tmpStatus := status.DeepCopy()
+	status.Summary.TimeStamp = time.Now().String()
+	status.Conditions[0].LastTransitionTime = v1.Now()
+	status.SubResources["test"] = v1alpha1.Status{
+		Status:    v1alpha1.SYNCED,
+		Message:   "All subresources synced",
+		TimeStamp: time.Now().String(),
+	}
+
+	//assert that timestamps are in fact different
+	assert.NotEqual(t, tmpStatus.Summary.TimeStamp, status.Summary.TimeStamp)
+	assert.NotEqual(t, tmpStatus.Conditions[0].LastTransitionTime, status.Conditions[0].LastTransitionTime)
+	assert.NotEqual(t, tmpStatus.SubResources["test"].TimeStamp, status.SubResources["test"].TimeStamp)
+
+	//assert zero diff
+	diff, err := GetObjectDiff(tmpStatus, status)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(diff))
 }

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -111,7 +111,7 @@ func (r *SKIPJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	if len(statusDiff) > 0 {
-		rLog.Info("Status has changed", "diff", statusDiff)
+		rLog.Debug("Status has changed", "diff", statusDiff)
 		err = r.GetClient().Status().Update(ctx, skipJob)
 		return reconcile.Result{Requeue: true}, err
 	}

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/nais/liberator/pkg/namegen"
-	"github.com/r3labs/diff/v3"
 	"hash/fnv"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -14,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
-	"reflect"
 	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
@@ -148,21 +146,6 @@ func EnsurePrefix(s string, prefix string) string {
 		return prefix + s
 	}
 	return s
-}
-
-func GetObjectDiff[T any](a T, b T) (diff.Changelog, error) {
-	aKind := reflect.ValueOf(a).Kind()
-	bKind := reflect.ValueOf(b).Kind()
-	if aKind != bKind {
-		return nil, fmt.Errorf("The objects to compare are not the same, found obj1: %v, obj2: %v\n", aKind, bKind)
-	}
-	changelog, err := diff.Diff(a, b)
-
-	if len(changelog) == 0 {
-		return nil, err
-	}
-
-	return changelog, nil
 }
 
 func IsCloudSqlProxyEnabled(gcp *podtypes.GCP) bool {


### PR DESCRIPTION
When we updated from the crd with the old status object to the new one we ran into a problem where status would be set to `status: {}`. On some applications this would cause an issue where skiperator couldn't update the application since it was an invalid object (missing status). To solve this we need to make sure status is set to the default pending value before we can update the spec.
I wasn't able to reproduce this issue with kind. 
Alternative solutions: 
- set default status with kubebuilder/CRD
- instead of diffing status, check if status == nil