### PR TITLE
fix: Autosync loop because we update access policy with ports

### DIFF
--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -171,6 +171,10 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		return reconcile.Result{Requeue: true}, err
 	}
 
+	//We try to feed the access policy with port values dynamically,
+	//if unsuccessfull we just don't set ports, and rely on podselectors
+	r.UpdateAccessPolicy(ctx, application)
+
 	//Start the actual reconciliation
 	rLog.Debug("Starting reconciliation loop", "application", application.Name)
 	r.SetProgressingState(ctx, application, fmt.Sprintf("Application %v has started reconciliation loop", application.Name))
@@ -317,10 +321,6 @@ func (r *ApplicationReconciler) setApplicationDefaults(application *skiperatorv1
 			application.Spec.Team = name
 		}
 	}
-
-	//We try to feed the access policy with port values dynamically,
-	//if unsuccessfull we just don't set ports, and rely on podselectors
-	r.UpdateAccessPolicy(ctx, application)
 
 	application.FillDefaultsStatus()
 }

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -123,6 +123,10 @@ func (r *SKIPJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{Requeue: true}, err
 	}
 
+	//We try to feed the access policy with port values dynamically,
+	//if unsuccessfull we just don't set ports, and rely on podselectors
+	r.UpdateAccessPolicy(ctx, skipJob)
+
 	//Start the actual reconciliation
 	rLog.Debug("Starting reconciliation loop")
 	r.SetProgressingState(ctx, skipJob, fmt.Sprintf("SKIPJob %v has started reconciliation loop", skipJob.Name))
@@ -198,9 +202,6 @@ func (r *SKIPJobReconciler) setSKIPJobDefaults(ctx context.Context, skipJob *ski
 	}
 	resourceutils.SetSKIPJobLabels(skipJob, skipJob)
 	skipJob.FillDefaultStatus()
-	//We try to feed the access policy with port values dynamically,
-	//if unsuccessfull we just don't set ports, and rely on podselectors
-	r.UpdateAccessPolicy(ctx, skipJob)
 
 	return nil
 }

--- a/tests/application/access-policy/advanced-error.yaml
+++ b/tests/application/access-policy/advanced-error.yaml
@@ -1,0 +1,35 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: access-policy
+  namespace: access-policy-ns
+spec:
+  image: image
+  port: 8080
+  accessPolicy:
+    inbound:
+      rules:
+        - application: access-policy-other
+          namespace: access-policy-other
+    outbound:
+      external:
+        - host: example.com
+          ports:
+            - name: http
+              port: 80
+              protocol: HTTP
+        - host: foo.com
+      rules:
+        - application: access-policy-two
+          ports:
+            - port: 8080
+              protocol: TCP
+        - application: access-policy-other
+          namespace: access-policy-other
+          ports:
+            - port: 8080
+              protocol: TCP
+status:
+  conditions:
+    - type: InternalRulesValid
+      status: "True"

--- a/tests/application/access-policy/chainsaw-test.yaml
+++ b/tests/application/access-policy/chainsaw-test.yaml
@@ -18,6 +18,8 @@ spec:
             file: advanced.yaml
         - assert:
             file: advanced-assert.yaml
+        - error:
+            file: advanced-error.yaml
     - try:
         - apply:
             file: advanced-patch.yaml

--- a/tests/skipjob/access-policy-job/chainsaw-test.yaml
+++ b/tests/skipjob/access-policy-job/chainsaw-test.yaml
@@ -18,8 +18,12 @@ spec:
             file: skipjob.yaml
         - assert:
             file: skipjob-assert.yaml
+        - error:
+            file: skipjob-error.yaml
     - try:
         - apply:
             file: skipjob-cron.yaml
         - assert:
             file: skipjob-cron-assert.yaml
+        - error:
+            file: skipjob-cron-error.yaml

--- a/tests/skipjob/access-policy-job/skipjob-assert.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-assert.yaml
@@ -88,9 +88,6 @@ spec:
           - host: foo.com
         rules:
           - application: minimal-application
-            ports:
-              - port: 8080
-                protocol: TCP
 status:
   conditions:
     - type: Failed

--- a/tests/skipjob/access-policy-job/skipjob-cron-error.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-cron-error.yaml
@@ -21,6 +21,9 @@ spec:
           - host: foo.com
         rules:
           - application: minimal-application
+            ports:
+              - port: 8080
+                protocol: TCP
   cron:
     schedule: "* * * * *"
 status:
@@ -34,32 +37,3 @@ status:
     - type: InternalRulesValid
       status: "True"
 
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: access-policy-cron-job-skipjob
-  ownerReferences:
-    - apiVersion: skiperator.kartverket.no/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: SKIPJob
-      name: access-policy-cron-job
-spec:
-  egress:
-    -  ports:
-         - port: 8080
-           protocol: TCP
-       to:
-         - namespaceSelector:
-             matchLabels:
-               kubernetes.io/metadata.name: access-policy-job-ns
-           podSelector:
-             matchLabels:
-               app: minimal-application
-  podSelector:
-    matchLabels:
-      app: access-policy-cron-job-skipjob
-  policyTypes:
-    - Egress
----

--- a/tests/skipjob/access-policy-job/skipjob-error.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-error.yaml
@@ -1,0 +1,36 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: SKIPJob
+metadata:
+  name: access-policy-job
+spec:
+  container:
+    image: "perl:5.34.0"
+    command:
+      - "perl"
+      - "-Mbignum=bpi"
+      - "-wle"
+      - "print bpi(2000)"
+    accessPolicy:
+      outbound:
+        external:
+          - host: example.com
+            ports:
+              - name: http
+                port: 80
+                protocol: HTTP
+          - host: foo.com
+        rules:
+          - application: minimal-application
+            ports:
+              - port: 8080
+                protocol: TCP
+status:
+  conditions:
+    - type: Failed
+      status: "False"
+    - type: Running
+      status: "True"
+    - type: Finished
+      status: "False"
+    - type: InternalRulesValid
+      status: "True"


### PR DESCRIPTION
Instead of updating the spec by setting it in the default spec function we just set the ports internally, with no change to the kubernetes resource.