### PR TITLE
Fix namespaceByLabel when multiple namespaces have same label

### DIFF
--- a/internal/controllers/common/reconciler.go
+++ b/internal/controllers/common/reconciler.go
@@ -224,7 +224,10 @@ func (r *ReconcilerBase) setPortsForRules(ctx context.Context, rules []podtypes.
 			namespaceList = append(namespaceList, rule.Namespace)
 		case len(rule.NamespacesByLabel) != 0:
 			selector := metav1.LabelSelector{MatchLabels: rule.NamespacesByLabel}
-			selectorString, _ := metav1.LabelSelectorAsSelector(&selector)
+			selectorString, err := metav1.LabelSelectorAsSelector(&selector)
+			if err != nil {
+			    return err
+			}
 			namespaces := &corev1.NamespaceList{}
 			if err := r.GetClient().List(ctx, namespaces, &client.ListOptions{LabelSelector: selectorString}); err != nil {
 				return err

--- a/tests/application/access-policy/chainsaw-test.yaml
+++ b/tests/application/access-policy/chainsaw-test.yaml
@@ -37,3 +37,8 @@ spec:
             file: access-policy-istio.yaml
         - assert:
             file: access-policy-istio-assert.yaml
+    - try:
+        - apply:
+            file: multiple-ns-same-label.yaml
+        - assert:
+            file: multiple-ns-same-label-assert.yaml

--- a/tests/application/access-policy/multiple-ns-same-label-assert.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: accesspolicy-app
+spec:
+  podSelector:
+    matchLabels:
+      app: accesspolicy-app
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              team: someteam
+          podSelector:
+            matchLabels:
+              app: app2
+      ports:
+        - port: 8085
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              team: eiet
+          podSelector:
+            matchLabels:
+              app: app
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 8082
+          protocol: TCP
+

--- a/tests/application/access-policy/multiple-ns-same-label-assert.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label-assert.yaml
@@ -24,7 +24,7 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
-              team: eiet
+              team: ateam
           podSelector:
             matchLabels:
               app: app

--- a/tests/application/access-policy/multiple-ns-same-label.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: eiet-main
+  name: ateam-main
   labels:
-    team: eiet
+    team: ateam
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: eiet-feat
+  name: ateam-feat
   labels:
-    team: eiet
+    team: ateam
 ---
 apiVersion: skiperator.kartverket.no/v1alpha1
 kind: Application
 metadata:
   name: app
-  namespace: eiet-main
+  namespace: ateam-main
 spec:
   image: image
   port: 8080
@@ -25,7 +25,7 @@ apiVersion: skiperator.kartverket.no/v1alpha1
 kind: Application
 metadata:
   name: app
-  namespace: eiet-feat
+  namespace: ateam-feat
 spec:
   image: image
   port: 8082
@@ -62,6 +62,6 @@ spec:
       rules:
         - application: app
           namespacesByLabel:
-            team: eiet
+            team: ateam
 
 

--- a/tests/application/access-policy/multiple-ns-same-label.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eiet-main
+  labels:
+    team: eiet
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eiet-feat
+  labels:
+    team: eiet
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app
+  namespace: eiet-main
+spec:
+  image: image
+  port: 8080
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app
+  namespace: eiet-feat
+spec:
+  image: image
+  port: 8082
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    team: someteam
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app2
+spec:
+  image: image
+  port: 8095
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: accesspolicy-app
+spec:
+  image: image
+  port: 8085
+  accessPolicy:
+    inbound:
+      rules:
+        - application: app2
+          namespacesByLabel:
+            team: someteam
+    outbound:
+      rules:
+        - application: app
+          namespacesByLabel:
+            team: eiet
+
+


### PR DESCRIPTION
https://kartverketgroup.slack.com/archives/C028ZEED280/p1724920375968729
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Enhanced namespace management allows for multiple namespaces to be processed for access policies.
  - Introduced a new Kubernetes NetworkPolicy to manage ingress and egress traffic based on labels and namespaces.

- **Bug Fixes**
  - Improved error handling for scenarios where no namespaces are found.

- **Tests**
  - Added new testing scenarios to cover multiple namespaces with the same label, expanding test coverage for access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->