### PR TITLE
Add AccessPolicies status

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -29,6 +29,7 @@ type ApplicationList struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName="app"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.summary.status`
+// +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -16,7 +16,6 @@ var (
 	DefaultBackoffLimit            = int32(6)
 
 	DefaultSuspend           = false
-	JobCreatedCondition      = "SKIPJobCreated"
 	ConditionRunning         = "Running"
 	ConditionFinished        = "Finished"
 	ConditionFailed          = "Failed"
@@ -35,6 +34,7 @@ type SKIPJobStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:object:generate=true
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.summary.status`
+// +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`
 //
 // SKIPJob is the Schema for the skipjobs API
 type SKIPJob struct {

--- a/api/v1alpha1/status_types.go
+++ b/api/v1alpha1/status_types.go
@@ -13,6 +13,8 @@ type SkiperatorStatus struct {
 	Summary      Status             `json:"summary"`
 	SubResources map[string]Status  `json:"subresources"`
 	Conditions   []metav1.Condition `json:"conditions"`
+	// Indicates if access policies are valid
+	AccessPolicies StatusNames `json:"accessPolicies"`
 }
 
 // Status
@@ -30,10 +32,12 @@ type Status struct {
 type StatusNames string
 
 const (
-	SYNCED      StatusNames = "Synced"
-	PROGRESSING StatusNames = "Progressing"
-	ERROR       StatusNames = "Error"
-	PENDING     StatusNames = "Pending"
+	SYNCED        StatusNames = "Synced"
+	PROGRESSING   StatusNames = "Progressing"
+	ERROR         StatusNames = "Error"
+	PENDING       StatusNames = "Pending"
+	READY         StatusNames = "Ready"
+	INVALIDCONFIG StatusNames = "InvalidConfig"
 )
 
 func (s *SkiperatorStatus) SetSummaryPending() {
@@ -62,6 +66,7 @@ func (s *SkiperatorStatus) SetSummaryProgressing() {
 		s.Conditions = make([]metav1.Condition, 0)
 	}
 	s.SubResources = make(map[string]Status)
+	s.AccessPolicies = PENDING
 }
 
 func (s *SkiperatorStatus) SetSummaryError(errorMsg string) {

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .status.summary.status
       name: Status
       type: string
+    - jsonPath: .status.accessPolicies
+      name: AccessPolicies
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -1099,6 +1102,9 @@ spec:
 
               A status field shown on a Skiperator resource which contains information regarding deployment of the resource.
             properties:
+              accessPolicies:
+                description: Indicates if access policies are valid
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current
@@ -1192,6 +1198,7 @@ spec:
                 - timestamp
                 type: object
             required:
+            - accessPolicies
             - conditions
             - subresources
             - summary

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -76,6 +76,9 @@ spec:
 
               A status field shown on a Skiperator resource which contains information regarding deployment of the resource.
             properties:
+              accessPolicies:
+                description: Indicates if access policies are valid
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current
@@ -169,6 +172,7 @@ spec:
                 - timestamp
                 type: object
             required:
+            - accessPolicies
             - conditions
             - subresources
             - summary

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.summary.status
       name: Status
       type: string
+    - jsonPath: .status.accessPolicies
+      name: AccessPolicies
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -853,6 +856,9 @@ spec:
 
               A status field shown on a Skiperator resource which contains information regarding deployment of the resource.
             properties:
+              accessPolicies:
+                description: Indicates if access policies are valid
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current
@@ -946,6 +952,7 @@ spec:
                 - timestamp
                 type: object
             required:
+            - accessPolicies
             - conditions
             - subresources
             - summary

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -326,8 +326,10 @@ func (r *SKIPJobReconciler) updateConditions(ctx context.Context, skipJob *skipe
 	accessPolicy := skipJob.Spec.Container.AccessPolicy
 	if accessPolicy != nil && !common.IsInternalRulesValid(accessPolicy) {
 		skipJob.Status.Conditions = append(skipJob.Status.Conditions, common.GetInternalRulesCondition(skipJob, v1.ConditionFalse))
+		skipJob.Status.AccessPolicies = skiperatorv1alpha1.INVALIDCONFIG
 	} else {
 		skipJob.Status.Conditions = append(skipJob.Status.Conditions, common.GetInternalRulesCondition(skipJob, v1.ConditionTrue))
+		skipJob.Status.AccessPolicies = skiperatorv1alpha1.READY
 	}
 
 	return nil

--- a/tests/application/access-policy/advanced-assert.yaml
+++ b/tests/application/access-policy/advanced-assert.yaml
@@ -124,6 +124,7 @@ spec:
         - application: access-policy-other
           namespace: access-policy-other
 status:
+  accessPolicies: Ready
   conditions:
     - type: InternalRulesValid
       status: "True"

--- a/tests/application/access-policy/bad-policy-assert.yaml
+++ b/tests/application/access-policy/bad-policy-assert.yaml
@@ -10,6 +10,7 @@ spec:
       rules:
         - application: doesnt-exist
 status:
+  accessPolicies: InvalidConfig
   conditions:
     - type: InternalRulesValid
       status: "False"

--- a/tests/application/access-policy/no-policy-assert.yaml
+++ b/tests/application/access-policy/no-policy-assert.yaml
@@ -13,3 +13,5 @@ metadata:
 spec:
   image: image
   port: 8080
+status:
+  accessPolicies: Ready

--- a/tests/skipjob/access-policy-job/application-assert.yaml
+++ b/tests/skipjob/access-policy-job/application-assert.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   image: image
   port: 8080
+status:
+  accessPolicies: Ready
 ---
 apiVersion: v1
 kind: Service

--- a/tests/skipjob/access-policy-job/skipjob-assert.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-assert.yaml
@@ -91,6 +91,7 @@ spec:
         rules:
           - application: minimal-application
 status:
+  accessPolicies: Ready
   conditions:
     - type: Failed
       status: "False"

--- a/tests/skipjob/conditions/skipjob-assert.yaml
+++ b/tests/skipjob/conditions/skipjob-assert.yaml
@@ -3,6 +3,7 @@ kind: SKIPJob
 metadata:
   name: condition-finish
 status:
+  accessPolicies: Ready
   conditions:
     - type: Failed
       status: "False"
@@ -18,6 +19,7 @@ kind: SKIPJob
 metadata:
   name: condition-running
 status:
+  accessPolicies: Ready
   conditions:
     - type: Failed
       status: "False"
@@ -33,6 +35,7 @@ kind: SKIPJob
 metadata:
   name: condition-fail
 status:
+  accessPolicies: InvalidConfig
   conditions:
     - type: Failed
       status: "True"


### PR DESCRIPTION
This adds the printer column "AccessPolicies" and gives us feedback if the access policy configuration is valid 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new "AccessPolicies" column to the `ApplicationList` for enhanced visibility of access control configurations.
	- Introduced `accessPolicies` field in multiple resource definitions, indicating the validity of access policies.

- **Bug Fixes**
	- Updated application and SKIP job status logic to accurately reflect access policy validity as either `READY` or `INVALIDCONFIG`.

- **Tests**
	- Enhanced test configurations to include `accessPolicies` status, improving monitoring and validation of access policies across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->