### PR TITLE
fix bug where access policy would stop adding ports if app doesn't ex…

### DIFF
--- a/tests/application/access-policy/bad-policy-assert.yaml
+++ b/tests/application/access-policy/bad-policy-assert.yaml
@@ -79,3 +79,6 @@ involvedObject:
   apiVersion: skiperator.kartverket.no/v1alpha1
   kind: Application
   name: no-namespace-with-labels
+message: >-
+  failed to set ports for outbound rules: expected namespace, but found none for
+  application access-policy-other

--- a/tests/application/access-policy/multiple-ns-same-label-assert.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label-assert.yaml
@@ -29,8 +29,9 @@ spec:
             matchLabels:
               app: app
       ports:
-        - port: 8080
-          protocol: TCP
         - port: 8082
           protocol: TCP
+        - port: 8080
+          protocol: TCP
+
 

--- a/tests/application/access-policy/multiple-ns-same-label.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label.yaml
@@ -60,6 +60,9 @@ spec:
             team: someteam
     outbound:
       rules:
+        - application: idontexist
+          namespacesByLabel:
+              team: ateam
         - application: app
           namespacesByLabel:
             team: ateam

--- a/tests/application/access-policy/multiple-ns-same-label.yaml
+++ b/tests/application/access-policy/multiple-ns-same-label.yaml
@@ -61,10 +61,15 @@ spec:
     outbound:
       rules:
         - application: idontexist
+        - application: idontexist
+          namespacesByLabel:
+            nonexisting: label
+        - application: idontexist
           namespacesByLabel:
               team: ateam
         - application: app
           namespacesByLabel:
             team: ateam
+
 
 


### PR DESCRIPTION
…ist in namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new outbound rule for an application labeled `idontexist`, enhancing application interaction with namespaces.
	- Added specific error messaging for outbound rule failures, aiding in debugging and configuration validation.

- **Bug Fixes**
	- Improved error handling for target application retrieval, allowing for graceful handling of "not found" scenarios.
	- Enhanced robustness in port assignment logic to prevent nil pointer dereference issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->