### PR TITLE
bug: not scaling up from 0 replicas using hpa

### DIFF
--- a/pkg/resourceprocessor/resource.go
+++ b/pkg/resourceprocessor/resource.go
@@ -38,10 +38,10 @@ func preparePatch(new client.Object, old client.Object) {
 		// If the replicas field is not set in the definition, we should set it to 1 if the deployment has 0 replicas or HPA will not work.
 		// If the replicas field is set in the definition, we should use that value so we don't scale down.
 		if definition.Spec.Replicas == nil {
+			definition.Spec.Replicas = deployment.Spec.Replicas
+
 			if *deployment.Spec.Replicas == int32(0) {
 				definition.Spec.Replicas = util.PointTo(int32(1))
-			} else {
-				definition.Spec.Replicas = deployment.Spec.Replicas
 			}
 		}
 		// The command "kubectl rollout restart" puts an annotation on the deployment template in order to track

--- a/pkg/resourceprocessor/resource.go
+++ b/pkg/resourceprocessor/resource.go
@@ -33,8 +33,16 @@ func preparePatch(new client.Object, old client.Object) {
 	case *v1.Deployment:
 		deployment := old.(*v1.Deployment)
 		definition := new.(*v1.Deployment)
+
+		// Handling HPA.
+		// If the replicas field is not set in the definition, we should set it to 1 if the deployment has 0 replicas or HPA will not work.
+		// If the replicas field is set in the definition, we should use that value so we don't scale down.
 		if definition.Spec.Replicas == nil {
-			definition.Spec.Replicas = deployment.Spec.Replicas
+			if *deployment.Spec.Replicas == int32(0) {
+				definition.Spec.Replicas = util.PointTo(int32(1))
+			} else {
+				definition.Spec.Replicas = deployment.Spec.Replicas
+			}
 		}
 		// The command "kubectl rollout restart" puts an annotation on the deployment template in order to track
 		// rollouts of different replicasets. This annotation must not trigger a new reconcile, and a quick and easy

--- a/tests/application/hpa/chainsaw-test.yaml
+++ b/tests/application/hpa/chainsaw-test.yaml
@@ -31,5 +31,8 @@ spec:
             file: patch-application-set-0-assert.yaml
         - error:
             file: patch-application-set-0-error.yaml
-
-
+    - try:
+        - apply:
+            file: patch-application-scale-up-from-0.yaml
+        - assert:
+            file: patch-application-scale-up-from-0-assert.yaml

--- a/tests/application/hpa/patch-application-scale-up-from-0-assert.yaml
+++ b/tests/application/hpa/patch-application-scale-up-from-0-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment-hpa
+spec:
+  replicas: 2
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: test-deployment-hpa
+spec:
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 200
+          type: Utilization
+      type: Resource
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: test-deployment-hpa
+

--- a/tests/application/hpa/patch-application-scale-up-from-0.yaml
+++ b/tests/application/hpa/patch-application-scale-up-from-0.yaml
@@ -1,0 +1,11 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: test-deployment-hpa
+spec:
+  image: image
+  port: 8080
+  replicas:
+    min: 2
+    max: 4
+    targetCpuUtilization: 200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test for handling zero replicas in deployments.
	- Enhanced deployment scaling logic for better Horizontal Pod Autoscaler (HPA) functionality.
	- Added new Kubernetes Application resource with dynamic scaling capabilities based on CPU utilization.

- **Bug Fixes**
	- Improved handling of replicas when deploying applications with zero replicas.

- **Tests**
	- Added new operations and assertions in test configurations to validate scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->