### PR TITLE
Include load balancer on cloud clusters in default deny netpol

### DIFF
--- a/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
+++ b/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
@@ -34,6 +34,12 @@ func Generate(r reconciliation.Reconciliation) error {
 							CIDR: "10.40.0.0/16",
 						},
 					},
+					// Egress rule for internal load balancer on cloud clusters
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "10.142.3.10/32",
+						},
+					},
 					// Egress rule for Internet
 					{
 						IPBlock: &networkingv1.IPBlock{

--- a/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
+++ b/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
@@ -34,10 +34,22 @@ func Generate(r reconciliation.Reconciliation) error {
 							CIDR: "10.40.0.0/16",
 						},
 					},
-					// Egress rule for internal load balancer on cloud clusters
+					// Egress rule for internal load balancer on atgcp1-sandbox
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "10.142.5.10/32",
+						},
+					},
+					// Egress rule for internal load balancer on atgcp1-dev
 					{
 						IPBlock: &networkingv1.IPBlock{
 							CIDR: "10.142.3.10/32",
+						},
+					},
+					// Egress rule for internal load balancer on atgcp1-prod
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "10.142.1.10/32",
 						},
 					},
 					// Egress rule for Internet

--- a/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
+++ b/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
@@ -37,19 +37,19 @@ func Generate(r reconciliation.Reconciliation) error {
 					// Egress rule for internal load balancer on atgcp1-sandbox
 					{
 						IPBlock: &networkingv1.IPBlock{
-							CIDR: "10.142.5.10/32",
+							CIDR: "10.142.5.0/28",
 						},
 					},
 					// Egress rule for internal load balancer on atgcp1-dev
 					{
 						IPBlock: &networkingv1.IPBlock{
-							CIDR: "10.142.3.10/32",
+							CIDR: "10.142.3.0/28",
 						},
 					},
 					// Egress rule for internal load balancer on atgcp1-prod
 					{
 						IPBlock: &networkingv1.IPBlock{
-							CIDR: "10.142.1.10/32",
+							CIDR: "10.142.1.0/28",
 						},
 					},
 					// Egress rule for Internet

--- a/tests/namespace/default-deny/assert.yaml
+++ b/tests/namespace/default-deny/assert.yaml
@@ -14,6 +14,8 @@ spec:
     - ipBlock:
         cidr: 10.40.0.0/16
     - ipBlock:
+        cidr: 10.142.3.10/32
+    - ipBlock:
         cidr: 0.0.0.0/0
         except:
         - 10.0.0.0/8

--- a/tests/namespace/default-deny/assert.yaml
+++ b/tests/namespace/default-deny/assert.yaml
@@ -14,7 +14,11 @@ spec:
     - ipBlock:
         cidr: 10.40.0.0/16
     - ipBlock:
+        cidr: 10.142.5.10/32
+    - ipBlock:
         cidr: 10.142.3.10/32
+    - ipBlock:
+        cidr: 10.142.1.10/32
     - ipBlock:
         cidr: 0.0.0.0/0
         except:

--- a/tests/namespace/default-deny/assert.yaml
+++ b/tests/namespace/default-deny/assert.yaml
@@ -14,11 +14,11 @@ spec:
     - ipBlock:
         cidr: 10.40.0.0/16
     - ipBlock:
-        cidr: 10.142.5.10/32
+        cidr: 10.142.5.0/28
     - ipBlock:
-        cidr: 10.142.3.10/32
+        cidr: 10.142.3.0/28
     - ipBlock:
-        cidr: 10.142.1.10/32
+        cidr: 10.142.1.0/28
     - ipBlock:
         cidr: 0.0.0.0/0
         except:


### PR DESCRIPTION
The default-deny network policy specifies an egress rule for Internet (`0.0.0.0/0`) except the range `10.0.0.0/8`, which denies traffic to the internal load balancer on public cloud clusters (`10.142.3.0/28`, `10.142.5.0/28`, `10.142.1.0/28`).

This PR therefore includes egress rules to allow traffic to the internal load balancers on public cloud clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced additional egress rules for internal load balancers, enhancing network traffic management.
  
- **Bug Fixes**
	- Updated `NetworkPolicy` configuration to include new egress rules, ensuring proper traffic flow to specified IP blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->