### PR TITLE
Bump Istio to v1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	google.golang.org/protobuf v1.36.1
-	istio.io/api v1.22.3
-	istio.io/client-go v1.22.3
+	istio.io/api v1.24.2
+	istio.io/client-go v1.24.2
 	k8s.io/api v0.32.0
 	k8s.io/apiextensions-apiserver v0.32.0
 	k8s.io/apimachinery v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -1399,10 +1399,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v1.22.3 h1:V59wgcCm2fK2r137QBsddCDHNg0efg/DauIWEB9DFz8=
-istio.io/api v1.22.3/go.mod h1:S3l8LWqNYS9yT+d4bH+jqzH2lMencPkW7SKM1Cu9EyM=
-istio.io/client-go v1.22.3 h1:4WocGQYVTASpfn7tj1yGE8f0sgxzbxOkg56HX1LJQ5U=
-istio.io/client-go v1.22.3/go.mod h1:D/vNne1n5586423NgGXMnPgshE/99mQgnjnxK/Vw2yM=
+istio.io/api v1.24.2 h1:jYjcN6Iq0RPtQj/3KMFsybxmfqmjGN/dxhL7FGJEdIM=
+istio.io/api v1.24.2/go.mod h1:MQnRok7RZ20/PE56v0LxmoWH0xVxnCQPNuf9O7PAN1I=
+istio.io/client-go v1.24.2 h1:JTTfBV6dv+AAW+AfccyrdX4T1f9CpsXd1Yzo1s/IYAI=
+istio.io/client-go v1.24.2/go.mod h1:dgZ9EmJzh1EECzf6nQhwNL4R6RvlyeH/RXeNeNp/MRg=
 k8s.io/api v0.32.0 h1:OL9JpbvAU5ny9ga2fb24X8H6xQlVp+aJMFlgtQjR9CE=
 k8s.io/api v0.32.0/go.mod h1:4LEwHZEf6Q/cG96F3dqR965sYOfmPM7rq81BLgsE0p0=
 k8s.io/apiextensions-apiserver v0.32.0 h1:S0Xlqt51qzzqjKPxfgX1xh4HBZE+p8KKBq+k2SWNOE0=

--- a/pkg/resourcegenerator/istio/virtualservice/application.go
+++ b/pkg/resourcegenerator/istio/virtualservice/application.go
@@ -49,13 +49,6 @@ func generateForApplication(r reconciliation.Reconciliation) error {
 				Name: "redirect-to-https",
 				Match: []*networkingv1api.HTTPMatchRequest{
 					{
-						WithoutHeaders: map[string]*networkingv1api.StringMatch{
-							":path": {
-								MatchType: &networkingv1api.StringMatch_Prefix{
-									Prefix: "/.well-known/acme-challenge/",
-								},
-							},
-						},
 						Port: 80,
 					},
 				},

--- a/pkg/resourcegenerator/istio/virtualservice/routing.go
+++ b/pkg/resourcegenerator/istio/virtualservice/routing.go
@@ -46,13 +46,6 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 			Name: "redirect-to-https",
 			Match: []*networkingv1api.HTTPMatchRequest{
 				{
-					WithoutHeaders: map[string]*networkingv1api.StringMatch{
-						":path": {
-							MatchType: &networkingv1api.StringMatch_Prefix{
-								Prefix: "/.well-known/acme-challenge/",
-							},
-						},
-					},
 					Port: 80,
 				},
 			},

--- a/tests/application/custom-certificate/application-duplicate-ingress-assert.yaml
+++ b/tests/application/custom-certificate/application-duplicate-ingress-assert.yaml
@@ -122,9 +122,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            ':path':
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308

--- a/tests/application/custom-certificate/application-duplicate-ingress-error.yaml
+++ b/tests/application/custom-certificate/application-duplicate-ingress-error.yaml
@@ -38,9 +38,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            ':path':
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308

--- a/tests/application/ingress/application-assert.yaml
+++ b/tests/application/ingress/application-assert.yaml
@@ -70,9 +70,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       redirect:
         redirectCode: 308
         scheme: https

--- a/tests/application/ingress/application-ingress-multiple-ports-assert.yaml
+++ b/tests/application/ingress/application-ingress-multiple-ports-assert.yaml
@@ -70,9 +70,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       redirect:
         redirectCode: 308
         scheme: https

--- a/tests/application/ingress/patch-application-change-ingress-assert.yaml
+++ b/tests/application/ingress/patch-application-change-ingress-assert.yaml
@@ -43,9 +43,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       redirect:
         redirectCode: 308
         scheme: https

--- a/tests/routing/routes/patch-application-change-port-assert.yaml
+++ b/tests/routing/routes/patch-application-change-port-assert.yaml
@@ -60,9 +60,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308

--- a/tests/routing/routes/patch-routing-change-hostname-assert.yaml
+++ b/tests/routing/routes/patch-routing-change-hostname-assert.yaml
@@ -57,9 +57,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308

--- a/tests/routing/routes/patch-routing-change-path-assert.yaml
+++ b/tests/routing/routes/patch-routing-change-path-assert.yaml
@@ -14,9 +14,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308

--- a/tests/routing/routes/patch-routing-remove-path-assert.yaml
+++ b/tests/routing/routes/patch-routing-remove-path-assert.yaml
@@ -37,9 +37,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308

--- a/tests/routing/routes/routing-assert.yaml
+++ b/tests/routing/routes/routing-assert.yaml
@@ -103,9 +103,6 @@ spec:
   http:
     - match:
         - port: 80
-          withoutHeaders:
-            :path:
-              prefix: /.well-known/acme-challenge/
       name: redirect-to-https
       redirect:
         redirectCode: 308


### PR DESCRIPTION
I've removed the negated matching for `/.well-known/acme-challenge/` since it now fails validation (probably since Istio 1.23). See https://github.com/istio/istio/issues/27643#issuecomment-2300514278.

When testing this configuration manually (by modifying a `VirtualService`) the more specific `Ingress` provisioned by cert-manager takes precedence of the more generic `VirtualService`es provisioned by skiperator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Upgraded Istio API and client-go dependencies from v1.22.3 to v1.24.2

- **Configuration Changes**
	- Removed `withoutHeaders` conditions from VirtualService configurations across multiple test and application files
	- Simplified HTTP to HTTPS redirection rules
	- Updated some hostname configurations in routing resources

- **Test Resources**
	- Added new Certificate and Gateway resources for additional domain support
	- Updated NetworkPolicy configurations for routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->