### PR TITLE
Submit transitive dependencies to dependency graph

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -1,0 +1,33 @@
+name: Publish dependencies to dependency graph
+
+on:
+  pull_request:
+  push:
+    branches:
+    - 'main'
+
+jobs:
+  dependency-submission:
+    permissions:
+      contents: write # Required for submitting dependencies
+      pull-requests: write # Required for dependency review comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Golang environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.1'
+
+      # This will also publish transitive dependencies not in go.mod
+      - name: Run snapshot action
+        uses: actions/go-dependency-submission@v2
+
+      # Comment on PRs
+      - name: Perform dependency review
+        uses: actions/dependency-review-action@v4
+        if: github.event_name == 'pull_request'
+        with:
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
Dependency graph currently only contains the dependencies declared in `go.mod`. By using the dependency submission API we can get notified about vulnerabilities in transitive dependencies. I.e., vulnerabilities for all dependencies listed in `go list -m all`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added a new GitHub Actions workflow to automatically track and review project dependencies.
	- Configured dependency submission for Go projects.
	- Enabled dependency graph updates on pull requests and main branch pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->