### PR TITLE
SKIP-1512 - Generate network policy if external rule is ip

### DIFF
--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -283,7 +283,7 @@ func (r *ApplicationReconciler) finalizeApplication(application *skiperatorv1alp
 		ctrlutil.RemoveFinalizer(application, applicationFinalizer)
 		err := r.GetClient().Update(ctx, application)
 		if err != nil {
-			return fmt.Errorf("Something went wrong when trying to finalize application. %w", err)
+			return fmt.Errorf("something went wrong when trying to finalize application. %w", err)
 		}
 	}
 

--- a/pkg/resourcegenerator/networkpolicy/dynamic/common.go
+++ b/pkg/resourcegenerator/networkpolicy/dynamic/common.go
@@ -9,7 +9,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"regexp"
+	"net"
 	"slices"
 	"strings"
 )
@@ -18,8 +18,6 @@ func init() {
 	multiGenerator.Register(reconciliation.ApplicationType, generateForCommon)
 	multiGenerator.Register(reconciliation.JobType, generateForCommon)
 }
-
-var ipAddress = regexp.MustCompile("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$")
 
 // TODO fix mess
 func generateForCommon(r reconciliation.Reconciliation) error {
@@ -98,7 +96,7 @@ func getEgressRules(accessPolicy *podtypes.AccessPolicy, appNamespace string) []
 	}
 
 	for _, externalRule := range accessPolicy.Outbound.External {
-		if externalRule.Ports == nil || externalRule.Ip == "" || !ipAddress.MatchString(externalRule.Ip) {
+		if externalRule.Ports == nil || externalRule.Ip == "" || net.ParseIP(externalRule.Ip) == nil {
 			continue
 		}
 		egressRules = append(egressRules, getIPExternalRule(externalRule))

--- a/tests/application/access-policy/chainsaw-test.yaml
+++ b/tests/application/access-policy/chainsaw-test.yaml
@@ -42,3 +42,8 @@ spec:
             file: multiple-ns-same-label.yaml
         - assert:
             file: multiple-ns-same-label-assert.yaml
+    - try:
+        - apply:
+            file: external-ip-policy.yaml
+        - assert:
+            file: external-ip-policy-assert.yaml

--- a/tests/application/access-policy/external-ip-policy-assert.yaml
+++ b/tests/application/access-policy/external-ip-policy-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: external-ip-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: external-ip-policy
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 5432
+      to:
+        - ipBlock:
+            cidr: 22.134.52.36/32
+  policyTypes:
+    - Egress

--- a/tests/application/access-policy/external-ip-policy.yaml
+++ b/tests/application/access-policy/external-ip-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: external-ip-policy
+spec:
+  image: image
+  port: 8080
+  accessPolicy:
+    outbound:
+      external:
+        - host: xkcd.com
+        - host: backstage-db-sandbox
+          ip: 22.134.52.36
+          ports:
+            - name: sql
+              port: 5432
+              protocol: TCP
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated an error message for a more consistent presentation when finalizing applications.

- **New Features**
  - Enhanced processing for external network access by adding IP validation and port mapping for outbound rules.
  - Introduced a new application configuration that specifies external access with defined host and port rules.

- **Tests**
  - Expanded test coverage by adding scenarios to validate the behavior of external network access policies, including new assertions for the `external-ip-policy`.
  - Added a new test step to evaluate the application of the external IP policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->