### PR TITLE
Feat/jwker generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ run-local: build install-skiperator
 	./bin/skiperator
 
 .PHONY: setup-local
-setup-local: kind-cluster install-istio install-cert-manager install-prometheus-crds install-digdirator-crds install-skiperator
+setup-local: kind-cluster install-istio install-cert-manager install-prometheus-crds install-jwker-crds install-digdirator-crds install-skiperator
 	@echo "Cluster $(SKIPERATOR_CONTEXT) is setup"
 
 
@@ -84,6 +84,11 @@ install-cert-manager:
 install-prometheus-crds:
 	@echo "Installing prometheus crds"
 	@kubectl apply -f https://github.com/prometheus-operator/prometheus-operator/releases/download/v$(PROMETHEUS_VERSION)/stripped-down-crds.yaml --context $(SKIPERATOR_CONTEXT)
+
+.PHONY: install-jwker-crds
+install-jwker-crds:
+	@echo "Installing jwker crds"
+	@kubectl apply -f https://raw.githubusercontent.com/nais/liberator/refs/heads/main/config/crd/bases/nais.io_jwkers.yaml --context $(SKIPERATOR_CONTEXT)
 
 .PHONY: install-digdirator-crds
 install-digdirator-crds:

--- a/api/v1alpha1/podtypes/access_policy.go
+++ b/api/v1alpha1/podtypes/access_policy.go
@@ -22,6 +22,11 @@ type AccessPolicy struct {
 	//
 	//+kubebuilder:validation:Optional
 	Outbound *OutboundPolicy `json:"outbound,omitempty"`
+
+	// TokenX enables the use of TokenX for authentication and authorization.
+	//
+	//+kubebuilder:validation:Optional
+	TokenX bool `json:"tokenX,omitempty"`
 }
 
 // InboundPolicy

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -254,6 +254,10 @@ spec:
                           type: object
                         type: array
                     type: object
+                  tokenX:
+                    description: TokenX enables the use of TokenX for authentication
+                      and authorization.
+                    type: boolean
                 type: object
               additionalPorts:
                 description: |-

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -268,6 +268,10 @@ spec:
                               type: object
                             type: array
                         type: object
+                      tokenX:
+                        description: TokenX enables the use of TokenX for authentication
+                          and authorization.
+                        type: boolean
                     type: object
                   additionalPorts:
                     items:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -116,6 +116,7 @@ rules:
   - nais.io
   resources:
   - idportenclients
+  - jwkers
   - maskinportenclients
   verbs:
   - create

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 // indirect
@@ -159,6 +160,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nais/jwker v0.0.0-20250120034305-b6c14be77dcd // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
@@ -206,15 +208,18 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/telemetry v0.0.0-20241108154256-525ce2e96f55 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
+	golang.org/x/vuln v1.1.4 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/api v0.214.0 // indirect
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
@@ -226,11 +231,13 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	honnef.co/go/tools v0.5.1 // indirect
 	k8s.io/apiserver v0.32.1 // indirect
 	k8s.io/component-base v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
+	mvdan.cc/gofumpt v0.7.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
@@ -648,6 +650,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nais/digdirator v0.0.0-20250120231831-742d74849567 h1:91UhhV75ffS92Yzs0QbN8gk3zNjANa2T7PdLsuW4ixc=
 github.com/nais/digdirator v0.0.0-20250120231831-742d74849567/go.mod h1:h82Ls+tjm28aU89GsU8txNMXWZOBkm/I2BEp7yMaMe8=
+github.com/nais/jwker v0.0.0-20250120034305-b6c14be77dcd h1:1ICM2FDI9zr6EsVILB4AjdfF5UAWRcRGhcfMy+lpTM0=
+github.com/nais/jwker v0.0.0-20250120034305-b6c14be77dcd/go.mod h1:rt0I23XEfJyWbrOM1UTsSq4oePCcQfRQjPogm4MDV0k=
 github.com/nais/liberator v0.0.0-20250120121331-1a7304c71267 h1:Ngg/i5VCv0yinrrlOef9ualH6Xml0Ga3DcxlfESUHFU=
 github.com/nais/liberator v0.0.0-20250120121331-1a7304c71267/go.mod h1:DtQgc26XvoZFe8jy0++wbuFUu5yCFTQ3vGV+y7TA7Uw=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -847,6 +851,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
+golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f h1:WTyX8eCCyfdqiPYkRGm0MqElSfYFH3yR1+rl/mct9sA=
+golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1044,6 +1050,8 @@ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/telemetry v0.0.0-20241108154256-525ce2e96f55 h1:ZZOVC4W26kVZSAW314SD81pWtiRgWNMbZsgLqKXx9lE=
+golang.org/x/telemetry v0.0.0-20241108154256-525ce2e96f55/go.mod h1:7Vh679jcBo81KQrd4wo0gKov7BE6IHwu1tEhHxHNM30=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -1130,6 +1138,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
 golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
+golang.org/x/vuln v1.1.4 h1:Ju8QsuyhX3Hk8ma3CesTbO8vfJD9EvUBgHvkxHBzj0I=
+golang.org/x/vuln v1.1.4/go.mod h1:F+45wmU18ym/ca5PLTPLsSzr2KppzswxPP603ldA67s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1396,6 +1406,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.5.1 h1:4bH5o3b5ZULQ4UrBmP+63W9r7qIkqJClEA9ko5YKx+I=
+honnef.co/go/tools v0.5.1/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=
 istio.io/api v1.24.2 h1:jYjcN6Iq0RPtQj/3KMFsybxmfqmjGN/dxhL7FGJEdIM=
 istio.io/api v1.24.2/go.mod h1:MQnRok7RZ20/PE56v0LxmoWH0xVxnCQPNuf9O7PAN1I=
 istio.io/client-go v1.24.2 h1:JTTfBV6dv+AAW+AfccyrdX4T1f9CpsXd1Yzo1s/IYAI=
@@ -1420,6 +1432,8 @@ k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 h1:hcha5B1kVACrLujCKLbr8X
 k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7/go.mod h1:GewRfANuJ70iYzvn+i4lezLDAFzvjxZYK1gn1lWcfas=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+mvdan.cc/gofumpt v0.7.0 h1:bg91ttqXmi9y2xawvkuMXyvAA/1ZGJqYAEGjXuP0JXU=
+mvdan.cc/gofumpt v0.7.0/go.mod h1:txVFJy/Sc/mvaycET54pV8SW8gWxTlUuGHVEcncmNUo=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -68,7 +68,7 @@ import (
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nais.io,resources=maskinportenclients;idportenclients,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nais.io,resources=maskinportenclients;idportenclients;jwkers,verbs=get;list;watch;create;update;patch;delete
 
 type ApplicationReconciler struct {
 	common.ReconcilerBase

--- a/pkg/resourcegenerator/jwker/jwker.go
+++ b/pkg/resourcegenerator/jwker/jwker.go
@@ -1,0 +1,104 @@
+package jwker
+
+import (
+	"fmt"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/reconciliation"
+	"github.com/kartverket/skiperator/pkg/util"
+	naisiov1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Generate(r reconciliation.Reconciliation) error {
+	ctxLog := r.GetLogger()
+	if r.GetType() != reconciliation.ApplicationType {
+		return fmt.Errorf("unsupported type %s in jwker resource", r.GetType())
+	}
+
+	application, ok := r.GetSKIPObject().(*skiperatorv1alpha1.Application)
+	if !ok {
+		err := fmt.Errorf("failed to cast resource to Application")
+		ctxLog.Error(err, "failed to generate jwker resource")
+		return err
+	}
+
+	if application.Spec.AccessPolicy == nil {
+		return nil
+	}
+
+	ctxLog.Debug("Attempting to generate jwker resource for application", "application", application.Name)
+
+	var err error
+
+	jwker := naisiov1.Jwker{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "nais.io/v1",
+			Kind:       "Jwker",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: application.Namespace,
+			Name:      application.Name,
+		},
+	}
+
+	jwker.Spec, err = getJwkerSpec(application)
+	if err != nil {
+		return err
+	}
+
+	r.AddResource(&jwker)
+	ctxLog.Debug("Finished generating jwker resource for application", "application", application.Name)
+
+	return nil
+}
+
+// Assumes application.Spec.AccessPolicy is not nil
+func getJwkerSpec(application *skiperatorv1alpha1.Application) (naisiov1.JwkerSpec, error) {
+	secretName, err := GetJwkerSecretName(application.Name)
+	if err != nil {
+		return naisiov1.JwkerSpec{}, err
+	}
+
+	jwkerAccessPolicy, err := GenerateJwkerAccessPolicy(application)
+	if err != nil {
+		return naisiov1.JwkerSpec{}, err
+	}
+
+	spec := naisiov1.JwkerSpec{
+		AccessPolicy: jwkerAccessPolicy,
+		SecretName:   secretName,
+	}
+
+	return spec, nil
+}
+
+func GenerateJwkerAccessPolicy(application *skiperatorv1alpha1.Application) (*naisiov1.AccessPolicy, error) {
+	if application.Spec.AccessPolicy == nil {
+		return nil, fmt.Errorf("AccessPolicy is nil")
+	}
+
+	accessPolicy := application.Spec.AccessPolicy.DeepCopy()
+
+	jwkerAccessPolicy := &naisiov1.AccessPolicy{
+		Inbound: &naisiov1.AccessPolicyInbound{
+			Rules: []naisiov1.AccessPolicyInboundRule{},
+		},
+	}
+
+	for _, rule := range accessPolicy.Inbound.Rules {
+		jwkerRule := naisiov1.AccessPolicyInboundRule{
+			AccessPolicyRule: naisiov1.AccessPolicyRule{
+				Application: rule.Application,
+				Namespace:   rule.Namespace,
+			},
+		}
+		jwkerAccessPolicy.Inbound.Rules = append(jwkerAccessPolicy.Inbound.Rules, jwkerRule)
+	}
+
+	return jwkerAccessPolicy, nil
+}
+
+func GetJwkerSecretName(name string) (string, error) {
+	return util.GetSecretName("jwker", name)
+}

--- a/pkg/resourceschemas/schemas.go
+++ b/pkg/resourceschemas/schemas.go
@@ -74,6 +74,7 @@ func GetApplicationSchemas(scheme *runtime.Scheme) []unstructured.UnstructuredLi
 		&securityv1.AuthorizationPolicyList{},
 		&nais_io_v1.MaskinportenClientList{},
 		&nais_io_v1.IDPortenClientList{},
+		&nais_io_v1.JwkerList{},
 		&pov1.ServiceMonitorList{},
 		&pov1.PodMonitorList{},
 		&certmanagerv1.CertificateList{},


### PR DESCRIPTION
Sett opp slik at jwker-definisjonen genereres basert på reglene i inbound/outbound, og skrus på med et flagg.

Måtte rote en del med patching vs. updates for å unngå en reconciliation loop. Dette oppsettet funker, og oppdaterer jwker kun dersom det er endringer i jwker-definisjonen. Dette sikrerer at vi får rett miljøvariabler