### PR TITLE
add usage based metrics

### DIFF
--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kartverket/skiperator/internal/controllers/common"
 	"github.com/kartverket/skiperator/pkg/flags"
 	"github.com/kartverket/skiperator/pkg/k8sfeatures"
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/kartverket/skiperator/pkg/metrics/usage"
 	"github.com/kartverket/skiperator/pkg/resourceschemas"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -87,6 +89,11 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := usage.NewUsageMetrics(kubeconfig, log.NewLogger().WithName("usage-metrics")); err != nil {
+		setupLog.Error(err, "unable to configure usage metrics")
 		os.Exit(1)
 	}
 

--- a/pkg/metrics/usage/constants.go
+++ b/pkg/metrics/usage/constants.go
@@ -1,0 +1,22 @@
+package usage
+
+const (
+	// Common subsystem that all metrics are registered under
+	metricSubsystem = "skiperator"
+
+	// Organizational labels
+	labelTeam     = "team"
+	labelDivision = "division"
+
+	// CRD label
+	labelType = "type"
+
+	// Skiperator CRD types
+	typeApplication = "Application"
+	typeSKIPJob     = "SKIPJob"
+	typeRouting     = "Routing"
+
+	// For massaging data
+	countKey     = "count"
+	unknownValue = "unknown"
+)

--- a/pkg/metrics/usage/namespace.go
+++ b/pkg/metrics/usage/namespace.go
@@ -1,0 +1,53 @@
+package usage
+
+import (
+	"context"
+
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	metadata := prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      "namespace_metadata",
+		Help:      "Metadata regarding number of namespaces per team and division",
+	}
+	labels := []string{labelTeam, labelDivision}
+	registerGaugeVecFunc(metadata, labels, updateNamespace)
+}
+
+func updateNamespace(ctx context.Context, k client.Client, logger log.Logger, currentGauge *prometheus.GaugeVec) {
+	namespaces := &corev1.NamespaceList{}
+	if err := k.List(ctx, namespaces); err != nil {
+		logger.Error(err, "failed to list namespaces")
+		return
+	}
+
+	counts := make(map[string]map[string]float64)
+
+	// Count namespaces grouped by label combination
+	for _, ns := range namespaces.Items {
+		team := ns.Labels[labelTeam]
+		division := ns.Labels[labelDivision]
+
+		key := valueOrDefault(team) + "|" + valueOrDefault(division)
+		if counts[key] == nil {
+			counts[key] = map[string]float64{}
+		}
+		counts[key][countKey]++ // Increment count
+	}
+
+	// Reset and update metrics
+	currentGauge.Reset()
+	for key, _ := range counts {
+		labels := map[string]string{}
+		parts := splitKey(key)
+		labels[labelTeam] = parts[0]
+		labels[labelDivision] = parts[1]
+
+		currentGauge.With(labels).Set(counts[key][countKey])
+	}
+}

--- a/pkg/metrics/usage/team.go
+++ b/pkg/metrics/usage/team.go
@@ -1,0 +1,81 @@
+package usage
+
+import (
+	"context"
+
+	"github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var crdGVRs = []schema.GroupVersionResource{
+	v1alpha1.GroupVersion.WithResource(typeApplication),
+	v1alpha1.GroupVersion.WithResource(typeSKIPJob),
+	v1alpha1.GroupVersion.WithResource(typeRouting),
+}
+
+func init() {
+	metadata := prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      "team_usage",
+		Help:      "Number of active CRs per team and division",
+	}
+	labels := []string{labelTeam, labelDivision, labelType}
+	registerGaugeVecFunc(metadata, labels, updateTeamCRUsage)
+}
+
+func updateTeamCRUsage(ctx context.Context, k client.Client, logger log.Logger, currentGauge *prometheus.GaugeVec) {
+	// List all namespaces
+	namespaces := &corev1.NamespaceList{}
+	if err := k.List(ctx, namespaces); err != nil {
+		logger.Error(err, "failed to list namespaces")
+		return
+	}
+
+	// Initialize counts
+	counts := make(map[string]map[string]float64)
+
+	// Iterate over namespaces
+	for _, ns := range namespaces.Items {
+		team := ns.Labels[labelTeam]
+		division := ns.Labels[labelDivision]
+
+		key := valueOrDefault(team) + "|" + valueOrDefault(division)
+		if counts[key] == nil {
+			counts[key] = make(map[string]float64)
+		}
+
+		// Count instances of each CRD in the namespace
+		for _, gvr := range crdGVRs {
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(gvr.GroupVersion().WithKind(gvr.Resource + "List"))
+
+			if err := k.List(ctx, list, client.InNamespace(ns.Name)); err != nil {
+				logger.Error(err, "failed to list resources for", "gvr", gvr, "namespace", ns.Name)
+				continue
+			}
+
+			counts[key][gvr.Resource] += float64(len(list.Items))
+		}
+	}
+
+	// Reset and update metrics
+	currentGauge.Reset()
+	for key, metrics := range counts {
+		parts := splitKey(key)
+		team := parts[0]
+		division := parts[1]
+
+		for resourceType, count := range metrics {
+			currentGauge.With(prometheus.Labels{
+				labelTeam:     team,
+				labelDivision: division,
+				labelType:     resourceType,
+			}).Set(count)
+		}
+	}
+}

--- a/pkg/metrics/usage/usage.go
+++ b/pkg/metrics/usage/usage.go
@@ -1,0 +1,104 @@
+package usage
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const metricsRefreshInterval = 30 * time.Second
+
+var (
+	logger  log.Logger
+	kclient *client.Client
+	gauges  = make(map[string]computableGauge)
+)
+
+// updateGaugeFunc is a function that will be called when it's time to
+// update the gauge.
+type updateGaugeFunc = func(ctx context.Context, k client.Client, logger log.Logger, currentGauge *prometheus.GaugeVec)
+
+// computableGauge is a struct that holds a gauge and a function to update
+// it in order to make it easier to do bookkeeping
+type computableGauge struct {
+	gauge *prometheus.GaugeVec
+	fn    updateGaugeFunc
+}
+
+// NewUsageMetrics initializes the usage metrics subsystem, ensuring that metrics will be updated
+func NewUsageMetrics(k8sConfig *rest.Config, log log.Logger) error {
+	if k8sConfig == nil {
+		return errors.New("missing k8s REST config")
+	}
+
+	// Create a new controller-runtime client in order to
+	// utilize the built-in caching mechanisms
+	c, err := client.New(k8sConfig, client.Options{
+		Cache: &client.CacheOptions{
+			Unstructured: true,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create controller-runtime client")
+	}
+
+	kclient = &c
+	logger = log
+
+	// Start a background goroutine to update metrics periodically
+	go func() {
+		// initial update
+		updateMetrics(context.Background())
+		// regular update
+		ticker := time.NewTicker(metricsRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				updateMetrics(context.Background())
+			}
+		}
+	}()
+
+	return nil
+}
+
+func updateMetrics(ctx context.Context) {
+	logger.Debug("refreshing data and updating metrics")
+	for _, g := range gauges {
+		g.fn(ctx, *kclient, logger, g.gauge)
+	}
+}
+
+// registerGaugeVecFunc registers a gauge with the given options and label names with the
+// shared metrics registry.
+func registerGaugeVecFunc(opts prometheus.GaugeOpts, labelNames []string, fn updateGaugeFunc) {
+	g := prometheus.NewGaugeVec(opts, labelNames)
+	metrics.Registry.MustRegister(g)
+	gauges[opts.Name] = computableGauge{gauge: g, fn: fn}
+}
+
+// Helper function to split key back into label values
+func splitKey(key string) []string {
+	parts := [2]string{unknownValue, unknownValue}
+	split := strings.SplitN(key, "|", 2)
+	for i, val := range split {
+		parts[i] = val
+	}
+	return parts[:]
+}
+
+// Ensure empty string if label is missing to avoid "no metric for label set" errors
+func valueOrDefault(value string) string {
+	if len(value) == 0 {
+		return unknownValue
+	}
+	return value
+}


### PR DESCRIPTION
Exposes metrics in the following format

```
# HELP skiperator_namespace_metadata Metadata regarding number of namespaces per team and division
# TYPE skiperator_namespace_metadata gauge
skiperator_namespace_metadata{division="some-division",team="some-team"} 1
skiperator_namespace_metadata{division="unknown",team="unknown"} 10
# HELP skiperator_team_usage Number of active CRs per team and division
# TYPE skiperator_team_usage gauge
skiperator_team_usage{division="some-division",team="some-team",type="Application"} 2
skiperator_team_usage{division="some-division",team="some-team",type="Routing"} 0
skiperator_team_usage{division="some-division",team="some-team",type="SKIPJob"} 0
skiperator_team_usage{division="unknown",team="unknown",type="Application"} 1
skiperator_team_usage{division="unknown",team="unknown",type="Routing"} 0
skiperator_team_usage{division="unknown",team="unknown",type="SKIPJob"} 0
```

Some notable points:
- Updates gauges every 30 seconds
- Uses the controller-runtime Kubernetes client in order to use caching
- Every operation batch of operations against the apiserver is given a deadline of 20s in order to not block indefinitely

---
Closes SKIP-1494.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated a usage metrics subsystem that enhances monitoring from startup.
	- Added real-time tracking of Kubernetes namespaces and custom resource usage, organized by team and division.
	- Continuous background updates now provide up-to-date operational insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->