### PR TITLE
Bugfix JWT-auth

### DIFF
--- a/pkg/resourcegenerator/istio/authorizationpolicy/allow/authorization_policy.go
+++ b/pkg/resourcegenerator/istio/authorizationpolicy/allow/authorization_policy.go
@@ -27,10 +27,10 @@ func Generate(r reconciliation.Reconciliation) error {
 	}
 
 	var allowedPaths []string
+	// Include ignored paths from auth config as they should be accessible without authentication
+	allowedPaths = append(allowedPaths, r.GetAuthConfigs().GetIgnoredPaths()...)
 	if application.Spec.AuthorizationSettings != nil {
 		allowedPaths = append(allowedPaths, application.Spec.AuthorizationSettings.AllowList...)
-		// Include ignored paths from auth config as they should be accessible without authentication
-		allowedPaths = append(allowedPaths, r.GetAuthConfigs().GetIgnoredPaths()...)
 	}
 
 	// Generate an AuthorizationPolicy that allows requests to the list of paths in allowPaths

--- a/tests/application/jwt-auth/application-one-provider-with-secret-assert.yaml
+++ b/tests/application/jwt-auth/application-one-provider-with-secret-assert.yaml
@@ -47,7 +47,6 @@ spec:
       to:
         - operation:
             paths:
-              - /publicEndpoint
               - /loginIdPorten
   selector:
     matchLabels:

--- a/tests/application/jwt-auth/application-one-provider.yaml
+++ b/tests/application/jwt-auth/application-one-provider.yaml
@@ -7,9 +7,6 @@ spec:
   port: 8080
   ingresses:
     - example.com
-  authorizationSettings:
-    allowList:
-      - "/publicEndpoint"
   idporten:
     enabled: true
     integrationType: "api_klient"

--- a/tests/application/jwt-auth/application-two-providers-assert.yaml
+++ b/tests/application/jwt-auth/application-two-providers-assert.yaml
@@ -50,8 +50,8 @@ spec:
       to:
         - operation:
             paths:
-              - /publicEndpoint
               - /loginIdPorten
+              - /publicEndpoint
   selector:
     matchLabels:
       app: application-two


### PR DESCRIPTION
Applying the following skiperator application should allow unauthenticated requests to `/open` while require auth on all other paths.
```yaml
apiVersion: skiperator.kartverket.no/v1alpha1
kind: Application
metadata:
  name: application
spec:
  image: image
  port: 8080  
  idporten:
    enabled: true
    integrationType: "api_klient"
    scopes:
      - "openid"
    requestAuthentication:
      enabled: true
      ignorePaths: 
        - /open
```
The result was that an authorizationpolicy that allowed requests to `/open` was not created since allowed paths from idporten/maskinporten were only included if `spec.authorizationSettings != nil`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the authorization behavior by ensuring that all designated ignored paths are always consistently applied, regardless of other configuration settings. This update enhances the reliability of how authorization policies process request paths.
	- Adjusted access control rules by removing the `/publicEndpoint` from the allowed operations in `application-one`, while retaining access to `/loginIdPorten`.
	- Removed the `authorizationSettings` section related to public endpoint access in `application-one`.
	- Restored `/publicEndpoint` back into the allowed paths for `application-two`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->