### PR TITLE
Bugfix auth policies

### DIFF
--- a/api/v1alpha1/podtypes/access_policy.go
+++ b/api/v1alpha1/podtypes/access_policy.go
@@ -1,6 +1,9 @@
 package podtypes
 
-import v1 "k8s.io/api/networking/v1"
+import (
+	"fmt"
+	v1 "k8s.io/api/networking/v1"
+)
 
 // AccessPolicy
 //
@@ -128,4 +131,11 @@ type ExternalPort struct {
 	//+kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=HTTP;HTTPS;TCP;TLS
 	Protocol string `json:"protocol"`
+}
+
+func (internalRule *InternalRule) ToPrincipal(applicationNamespace string) string {
+	if internalRule.Namespace != "" {
+		return fmt.Sprintf("cluster.local/ns/%s/sa/%s", internalRule.Namespace, internalRule.Application)
+	}
+	return fmt.Sprintf("cluster.local/ns/%s/sa/%s", applicationNamespace, internalRule.Application)
 }

--- a/pkg/auth/auth_config.go
+++ b/pkg/auth/auth_config.go
@@ -17,6 +17,21 @@ type AuthConfig struct {
 	ProviderInfo  digdirator.DigdiratorInfo
 }
 
+func (authConfigs *AuthConfigs) GetAllPaths() []string {
+	var paths []string
+	if authConfigs != nil {
+		for _, config := range *authConfigs {
+			for _, ignoredPath := range config.IgnorePaths {
+				paths = append(paths, ignoredPath)
+			}
+			for _, allowPath := range config.Paths {
+				paths = append(paths, allowPath)
+			}
+		}
+	}
+	return paths
+}
+
 func (authConfigs *AuthConfigs) GetIgnoredPaths() []string {
 	ignoredPaths := map[string]string{}
 	allowPaths := map[string]string{}

--- a/pkg/resourcegenerator/istio/authorizationpolicy/common.go
+++ b/pkg/resourcegenerator/istio/authorizationpolicy/common.go
@@ -1,46 +1,12 @@
 package authorizationpolicy
 
 import (
-	"github.com/kartverket/skiperator/pkg/util"
 	v1 "istio.io/api/security/v1"
-	"istio.io/api/security/v1beta1"
-	typev1beta1 "istio.io/api/type/v1beta1"
-	securityv1 "istio.io/client-go/pkg/apis/security/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	DefaultDenyPath = "/actuator*"
 )
-
-func GetAuthPolicy(namespacedName types.NamespacedName, applicationName string, action v1beta1.AuthorizationPolicy_Action, paths []string, notPaths []string) *securityv1.AuthorizationPolicy {
-	return &securityv1.AuthorizationPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespacedName.Namespace,
-			Name:      namespacedName.Name,
-		},
-		Spec: v1.AuthorizationPolicy{
-			Action: action,
-			Rules: []*v1.Rule{
-				{
-					To: []*v1.Rule_To{
-						{
-							Operation: &v1.Operation{
-								Paths:    paths,
-								NotPaths: notPaths,
-							},
-						},
-					},
-					From: GetGeneralFromRule(),
-				},
-			},
-			Selector: &typev1beta1.WorkloadSelector{
-				MatchLabels: util.GetPodAppSelector(applicationName),
-			},
-		},
-	}
-}
 
 func GetGeneralFromRule() []*v1.Rule_From {
 	return []*v1.Rule_From{

--- a/pkg/resourcegenerator/istio/authorizationpolicy/default_deny/authorization_policy.go
+++ b/pkg/resourcegenerator/istio/authorizationpolicy/default_deny/authorization_policy.go
@@ -38,18 +38,13 @@ func Generate(r reconciliation.Reconciliation) error {
 
 	var notPaths []string
 	if application.Spec.AuthorizationSettings != nil {
-		for _, path := range application.Spec.AuthorizationSettings.AllowList {
-			if strings.HasPrefix(path, authorizationpolicy.DefaultDenyPath) {
-				notPaths = append(notPaths, path)
-			}
-		}
-		for _, path := range r.GetAuthConfigs().GetAllPaths() {
+		for _, path := range append(application.Spec.AuthorizationSettings.AllowList, r.GetAuthConfigs().GetAllPaths()...) {
 			if strings.HasPrefix(path, authorizationpolicy.DefaultDenyPath) {
 				notPaths = append(notPaths, path)
 			}
 		}
 	}
-	
+
 	r.AddResource(
 		&securityv1.AuthorizationPolicy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resourcegenerator/istio/authorizationpolicy/default_deny/authorization_policy.go
+++ b/pkg/resourcegenerator/istio/authorizationpolicy/default_deny/authorization_policy.go
@@ -5,8 +5,12 @@ import (
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/istio/authorizationpolicy"
+	"github.com/kartverket/skiperator/pkg/util"
 	securityv1api "istio.io/api/security/v1"
-	"k8s.io/apimachinery/pkg/types"
+	typev1beta1 "istio.io/api/type/v1beta1"
+	securityv1 "istio.io/client-go/pkg/apis/security/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
 
 func Generate(r reconciliation.Reconciliation) error {
@@ -32,17 +36,46 @@ func Generate(r reconciliation.Reconciliation) error {
 		ctxLog.Debug("No auth config provided. Defaults to deny-all AuthorizationPolicy for application", "application", application.Name)
 	}
 
+	var notPaths []string
+	if application.Spec.AuthorizationSettings != nil {
+		for _, path := range application.Spec.AuthorizationSettings.AllowList {
+			if strings.HasPrefix(path, authorizationpolicy.DefaultDenyPath) {
+				notPaths = append(notPaths, path)
+			}
+		}
+		for _, path := range r.GetAuthConfigs().GetAllPaths() {
+			if strings.HasPrefix(path, authorizationpolicy.DefaultDenyPath) {
+				notPaths = append(notPaths, path)
+			}
+		}
+	}
+	
 	r.AddResource(
-		authorizationpolicy.GetAuthPolicy(
-			types.NamespacedName{
+		&securityv1.AuthorizationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      application.Name + "-default-deny",
 				Namespace: application.Namespace,
 			},
-			application.Name,
-			securityv1api.AuthorizationPolicy_DENY,
-			[]string{defaultDenyPath},
-			[]string{},
-		),
+			Spec: securityv1api.AuthorizationPolicy{
+				Action: securityv1api.AuthorizationPolicy_DENY,
+				Rules: []*securityv1api.Rule{
+					{
+						To: []*securityv1api.Rule_To{
+							{
+								Operation: &securityv1api.Operation{
+									Paths:    []string{defaultDenyPath},
+									NotPaths: notPaths,
+								},
+							},
+						},
+						From: authorizationpolicy.GetGeneralFromRule(),
+					},
+				},
+				Selector: &typev1beta1.WorkloadSelector{
+					MatchLabels: util.GetPodAppSelector(application.Name),
+				},
+			},
+		},
 	)
 
 	ctxLog.Debug("Finished generating default AuthorizationPolicy for application", "application", application.Name)

--- a/tests/application/access-policy/chainsaw-test.yaml
+++ b/tests/application/access-policy/chainsaw-test.yaml
@@ -52,3 +52,8 @@ spec:
             file: dns-lookup.yaml
         - assert:
             file: dns-lookup-assert.yaml
+    - try:
+        - apply:
+            file: inbound-rules-auth-policy.yaml
+        - assert:
+            file: inbound-rules-auth-policy-assert.yaml

--- a/tests/application/access-policy/inbound-rules-auth-policy-assert.yaml
+++ b/tests/application/access-policy/inbound-rules-auth-policy-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: inbound-rules-auth-policy-allow-paths
+spec:
+  rules:
+    - from:
+        - source:
+            namespaces:
+              - istio-gateways
+      to:
+        - operation:
+            paths:
+              - /actuator/health
+              - /actuator/info
+              - /actuator/status
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/other-namespace/sa/other-app
+              - cluster.local/ns/access-policy-ns/sa/some-other-app
+  selector:
+    matchLabels:
+      app: inbound-rules-auth-policy

--- a/tests/application/access-policy/inbound-rules-auth-policy.yaml
+++ b/tests/application/access-policy/inbound-rules-auth-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: inbound-rules-auth-policy
+spec:
+  image: image
+  port: 8080
+  authorizationSettings:
+    allowList:
+      - /actuator/health
+      - /actuator/info
+      - /actuator/status
+  accessPolicy:
+    inbound:
+      rules:
+        - application: other-app
+          namespace: other-namespace
+        - application: some-other-app

--- a/tests/application/authorization-settings/multiple-application-assert.yaml
+++ b/tests/application/authorization-settings/multiple-application-assert.yaml
@@ -51,6 +51,9 @@ spec:
         - operation:
             paths:
               - /actuator*
+            notPaths:
+              - /actuator/health
+              - /actuator/info
   selector:
     matchLabels:
       app: allow-list

--- a/tests/application/authorization-settings/patch-application-assert.yaml
+++ b/tests/application/authorization-settings/patch-application-assert.yaml
@@ -4,7 +4,11 @@ metadata:
   name: allow-list-allow-paths
 spec:
   rules:
-    - to:
+    - from:
+        - source:
+            namespaces:
+              - istio-gateways
+      to:
         - operation:
             paths:
               - /actuator/info

--- a/tests/application/authorization-settings/patch-application-assert.yaml
+++ b/tests/application/authorization-settings/patch-application-assert.yaml
@@ -4,11 +4,7 @@ metadata:
   name: allow-list-allow-paths
 spec:
   rules:
-    - from:
-        - source:
-            namespaces:
-              - istio-gateways
-      to:
+    - to:
         - operation:
             paths:
               - /actuator/info
@@ -32,6 +28,9 @@ spec:
         - operation:
             paths:
               - /actuator*
+            notPaths:
+              - /actuator/info
+              - /actuator/shutdown
   selector:
     matchLabels:
       app: allow-list


### PR DESCRIPTION
Introducing requestAuthentication in application-manifest introduced two bugs:
- Default deny `AuhtorizationPolicy` did not exclude allowed paths from its policy, therefore denying access to paths with `/actuator` as prefix even if they were explicitly allowed (for example in `authorizationSettings.AllowList`).
- All `AuthorizationPolicies` added an from-rule specifying that the request have to come from `istio-gateways`. This is not a problem if only a deny policy is present, but if an allow-policy is present, it effectively blocks all internal traffic as those requests will never come from `istio-gateways`.

This PR aims to fix this by doing the following:
- Excluding paths mentioned in the application manifest as allowed in the default deny auth-policy (only if they have `/actuator` as prefix)
- If an allow-policy is created, a rule that allows access is created based on `accessPolicy.inbound.rules` like this:
```yaml
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
  name: application
spec:
  rules:
    - from:
        - source:
            principals:
              - cluster.local/ns/namespace/sa/other-app
```