### PR TITLE
fix duplicate network policy for cloudsqlproxy

### DIFF
--- a/api/v1alpha1/podtypes/gcp.go
+++ b/api/v1alpha1/podtypes/gcp.go
@@ -50,8 +50,7 @@ type CloudSQLProxySettings struct {
 
 	// Image version for the CloudSQL proxy sidecar.
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:="2.15.1"
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=false

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -537,7 +537,6 @@ spec:
                           role.
                         type: string
                       version:
-                        default: 2.15.1
                         description: Image version for the CloudSQL proxy sidecar.
                         type: string
                     required:

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -503,7 +503,6 @@ spec:
                               role.
                             type: string
                           version:
-                            default: 2.15.1
                             description: Image version for the CloudSQL proxy sidecar.
                             type: string
                         required:

--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
@@ -31,9 +31,9 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 	ctxLog.Debug("Attempting to generate service entries", "type", r.GetType())
 
 	object := r.GetSKIPObject()
-	accessPolicy := object.GetCommonSpec().AccessPolicy
-
+	accessPolicy := object.GetCommonSpec().AccessPolicy.DeepCopy()
 	accessPolicy, err := setCloudSqlRule(accessPolicy, object)
+
 	if err != nil {
 		return err
 	}

--- a/pkg/resourcegenerator/pod/pod.go
+++ b/pkg/resourcegenerator/pod/pod.go
@@ -19,6 +19,8 @@ const (
 	Hostname SkiperatorTopologyKey = "kubernetes.io/hostname"
 	// OnPremFailureDomain is populated to the underlying ESXi hostname by the GKE on VMware tooling.
 	OnPremFailureDomain SkiperatorTopologyKey = "onprem.gke.io/failure-domain-name"
+	// DefaultCloudSQLProxyVersion
+	DefaultCloudSQLProxyVersion = "2.15.1"
 )
 
 type PodOpts struct {
@@ -116,6 +118,10 @@ func CreateCloudSqlProxyContainer(cs *podtypes.CloudSQLProxySettings) corev1.Con
 
 	if !cs.PublicIP {
 		args = append(args, "--private-ip") // Forces the use of private IP
+	}
+
+	if cs.Version == "" {
+		cs.Version = DefaultCloudSQLProxyVersion
 	}
 
 	return corev1.Container{

--- a/tests/application/cloudsql-auth-proxy/chainsaw-test.yaml
+++ b/tests/application/cloudsql-auth-proxy/chainsaw-test.yaml
@@ -36,3 +36,4 @@ spec:
             file: application-public-ip.yaml
         - assert:
             file: application-public-ip-assert.yaml
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default version handling for the Cloud SQL Proxy, ensuring a fallback version is used when none is specified.
  
- **Changes**
	- Updated the `Version` field in the CloudSQLProxySettings to be optional in JSON representation.
	- Removed default version values in YAML configurations for CloudSQL proxy settings, requiring explicit version specification.

- **Bug Fixes**
	- Improved internal configuration handling to prevent unintended modifications, enhancing overall system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->