### PR TITLE
add proxy to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,9 @@ archives:
       - goos: windows
         format: zip
 
+gomod:
+  proxy: true
+
 dockers:
   - image_templates:
       - "ghcr.io/kartverket/skiperator:{{ .Tag }}-linux-amd64"


### PR DESCRIPTION
I want to reuse the api packages in https://github.com/kartverket/sql-metric-exporter-job so I need goreleaser to release packages in the go proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new configuration option that activates module proxy support, enhancing dependency management and build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->