### PR TITLE
Revert "Add workloadSelector on ServiceEntry (#646)"

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -427,10 +427,6 @@ func (a *Application) FillDefaultsStatus() {
 	}
 }
 
-func (a *Application) GetWorkloadName() string {
-	return a.Name
-}
-
 func (a *Application) GetStatus() *SkiperatorStatus {
 	return &a.Status
 }

--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -94,10 +94,6 @@ func (in *Routing) SetConditions(conditions []metav1.Condition) {
 	in.Status.Conditions = conditions
 }
 
-func (in *Routing) GetWorkloadName() string {
-	return in.Name
-}
-
 func (in *RoutingSpec) GetHost() (*Host, error) {
 	return NewHost(in.Hostname)
 }

--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -210,10 +210,6 @@ func (skipJob *SKIPJob) KindPostFixedName() string {
 	return strings.ToLower(fmt.Sprintf("%v-%v", skipJob.Name, skipJob.Kind))
 }
 
-func (skipJob *SKIPJob) GetWorkloadName() string {
-	return skipJob.KindPostFixedName()
-}
-
 func (skipJob *SKIPJob) GetStatus() *SkiperatorStatus {
 	return &skipJob.Status
 }

--- a/api/v1alpha1/skipns_types.go
+++ b/api/v1alpha1/skipns_types.go
@@ -18,10 +18,6 @@ func (n SKIPNamespace) GetStatus() *SkiperatorStatus {
 
 func (n SKIPNamespace) SetStatus(status SkiperatorStatus) {}
 
-func (n SKIPNamespace) GetWorkloadName() string {
-	return n.Name
-}
-
 func (n SKIPNamespace) GetDefaultLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":              n.Name,

--- a/api/v1alpha1/skipobj_interfaces.go
+++ b/api/v1alpha1/skipobj_interfaces.go
@@ -14,7 +14,6 @@ type SKIPObject interface {
 	SetStatus(status SkiperatorStatus)
 	GetDefaultLabels() map[string]string
 	GetCommonSpec() *CommonSpec
-	GetWorkloadName() string
 }
 
 var ErrNoGVK = fmt.Errorf("no GroupVersionKind found in the resources, cannot process resources")

--- a/tests/application/access-policy/advanced-assert.yaml
+++ b/tests/application/access-policy/advanced-assert.yaml
@@ -79,9 +79,6 @@ spec:
     - name: http
       number: 80
       protocol: HTTP
-  workloadSelector:
-    labels:
-      app: access-policy
 ---
 apiVersion: networking.istio.io/v1
 kind: ServiceEntry
@@ -100,9 +97,6 @@ spec:
     - name: https
       number: 443
       protocol: HTTPS
-  workloadSelector:
-    labels:
-      app: access-policy
 ---
 apiVersion: skiperator.kartverket.no/v1alpha1
 kind: Application

--- a/tests/application/access-policy/advanced-patch-assert.yaml
+++ b/tests/application/access-policy/advanced-patch-assert.yaml
@@ -15,9 +15,6 @@ spec:
     - name: https
       number: 443
       protocol: HTTPS
-  workloadSelector:
-    labels:
-      app: access-policy
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/tests/application/access-policy/dns-lookup-assert.yaml
+++ b/tests/application/access-policy/dns-lookup-assert.yaml
@@ -14,6 +14,3 @@ spec:
     - name: ldaps
       number: 636
       protocol: TLS
-  workloadSelector:
-    labels:
-      app: dns-lookup

--- a/tests/application/cloudsql-auth-proxy/application-assert.yaml
+++ b/tests/application/cloudsql-auth-proxy/application-assert.yaml
@@ -179,6 +179,8 @@ metadata:
 spec:
   addresses:
     - 10.0.0.1
+  endpoints:
+    - address: 10.0.0.1
   exportTo:
     - .
     - istio-system

--- a/tests/application/cloudsql-auth-proxy/set-version-assert.yaml
+++ b/tests/application/cloudsql-auth-proxy/set-version-assert.yaml
@@ -156,6 +156,8 @@ metadata:
 spec:
   addresses:
     - 10.0.0.1
+  endpoints:
+    - address: 10.0.0.1
   exportTo:
     - .
     - istio-system

--- a/tests/skipjob/access-policy-job/skipjob-assert.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-assert.yaml
@@ -49,9 +49,6 @@ spec:
       number: 443
       protocol: HTTPS
   resolution: DNS
-  workloadSelector:
-    labels:
-      app: access-policy-job-skipjob
 ---
 apiVersion: networking.istio.io/v1
 kind: ServiceEntry
@@ -69,9 +66,6 @@ spec:
       number: 80
       protocol: HTTP
   resolution: DNS
-  workloadSelector:
-    labels:
-      app: access-policy-job-skipjob
 ---
 apiVersion: skiperator.kartverket.no/v1alpha1
 kind: SKIPJob

--- a/tests/skipjob/cloudsql-auth-proxy-job/skipjob-assert.yaml
+++ b/tests/skipjob/cloudsql-auth-proxy-job/skipjob-assert.yaml
@@ -102,6 +102,8 @@ metadata:
 spec:
   addresses:
     - 10.0.0.1
+  endpoints:
+    - address: 10.0.0.1
   exportTo:
     - .
     - istio-system
@@ -113,6 +115,3 @@ spec:
       number: 3307
       protocol: TCP
   resolution: STATIC
-  workloadSelector:
-    labels:
-      app: randomjob-skipjob


### PR DESCRIPTION
This reverts commit 70d471b94d255e541f629f318ff8144a7bde55a9.

Reverting because this is an undocumented feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed direct workload name retrieval functionality from several components.
  - Updated service configuration to use explicit endpoint definitions for improved service discovery and routing.
- **Tests**
  - Revised test configurations by removing dynamic workload selection criteria.
  - Added explicit endpoint entries to validate the updated routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->