### PR TITLE
Dependabot: Ignore unstable releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "Europe/Oslo"
-
+    ignore:
+      versions:
+        - ".*-alpha.*"
+        - ".*-beta.*"
+        - ".*-rc.*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	google.golang.org/protobuf v1.36.6
-	istio.io/api v1.26.0-rc.0
+	istio.io/api v1.25.2
 	istio.io/client-go v1.25.2
 	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -2074,8 +2074,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
-istio.io/api v1.26.0-rc.0 h1:s419BJMDgmJKzAbP/yUM8/MO2Nm1VcIsKAPr9SZlhWM=
-istio.io/api v1.26.0-rc.0/go.mod h1:DTVGH6CLXj5W8FF9JUD3Tis78iRgT1WeuAnxfTz21Wg=
+istio.io/api v1.25.2 h1:FCRQy7iaTreKJdLemlQ1vRJEsf1soCHoTAuSf68w5I8=
+istio.io/api v1.25.2/go.mod h1:QFzEXv/IT582T0FHZVp1QoolvE4ws0zz/vVO55blmlE=
 istio.io/client-go v1.25.2 h1:faupTqeMD0PkuNTZdFlpxxT35jBSQapK5k+MNAkXvqA=
 istio.io/client-go v1.25.2/go.mod h1:E2LTxTcCVe4cqpKy4/9Y4VmwSoLiH6ff9MEG7EhfSDo=
 k8s.io/api v0.33.0 h1:yTgZVn1XEe6opVpP1FylmNrIFWuDqe2H0V8CT5gxfIU=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency management settings to ignore pre-release versions (alpha, beta, rc) for certain updates.
  - Downgraded a dependency to a stable version for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->