### PR TITLE
routing: fix missing support for '+' notation of hostnames

### DIFF
--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: applications.skiperator.kartverket.no
 spec:
   group: skiperator.kartverket.no

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: routings.skiperator.kartverket.no
 spec:
   group: skiperator.kartverket.no

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: skipjobs.skiperator.kartverket.no
 spec:
   group: skiperator.kartverket.no

--- a/pkg/resourcegenerator/istio/virtualservice/routing.go
+++ b/pkg/resourcegenerator/istio/virtualservice/routing.go
@@ -30,13 +30,18 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 		},
 	}
 
+	h, err := routing.Spec.GetHost()
+	if err != nil || h == nil {
+		return fmt.Errorf("failed to get host from routing: %w", err)
+	}
+
 	virtualService.Spec = networkingv1api.VirtualService{
 		ExportTo: []string{".", "istio-system", "istio-gateways"},
 		Gateways: []string{
 			routing.GetGatewayName(),
 		},
 		Hosts: []string{
-			routing.Spec.Hostname,
+			h.Hostname,
 		},
 		Http: []*networkingv1api.HTTPRoute{},
 	}

--- a/tests/routing/custom-certificate/routing-assert.yaml
+++ b/tests/routing/custom-certificate/routing-assert.yaml
@@ -38,3 +38,34 @@ spec:
       tls:
         credentialName: some-cert
         mode: SIMPLE
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: some-routing-routing-ingress
+spec:
+  exportTo:
+    - .
+    - istio-system
+    - istio-gateways
+  gateways:
+    - some-routing-routing-ingress
+  hosts:
+    - example.com
+  http:
+    - match:
+        - port: 80
+      name: redirect-to-https
+      redirect:
+        redirectCode: 308
+        scheme: https
+    - match:
+        - port: 443
+          uri:
+            prefix: /app1
+      name: some-app
+      route:
+        - destination:
+            host: some-app
+            port:
+              number: 8081


### PR DESCRIPTION
Without this fix, invalid `VirtualService`s will be generated with hostnames like `example.com+some-cert`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated metadata annotations to reflect a newer controller-gen tool version for several configuration files. No functional changes were made.
- **Bug Fixes**
  - Improved error handling and validation when extracting host information for routing, ensuring more robust configuration generation.
- **Tests**
  - Added a new test resource to verify HTTP to HTTPS redirection and specific routing behavior for secure traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->