### PR TITLE
SKIP-1562--Remove-grafana-agent-from-network-policy

### DIFF
--- a/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
+++ b/pkg/resourcegenerator/networkpolicy/defaultdeny/default_deny_network_policy.go
@@ -103,32 +103,6 @@ func Generate(r reconciliation.Reconciliation) error {
 					},
 				},
 			},
-			// Egress rule for grafana-agent
-			{
-				To: []networkingv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "grafana-agent"},
-						},
-						PodSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/instance": "grafana-agent",
-								"app.kubernetes.io/name":     "grafana-agent",
-							},
-						},
-					},
-				},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{
-						Protocol: util.PointTo(corev1.ProtocolTCP),
-						Port:     util.PointTo(intstr.FromInt(4317)),
-					},
-					{
-						Protocol: util.PointTo(corev1.ProtocolTCP),
-						Port:     util.PointTo(intstr.FromInt(4318)),
-					},
-				},
-			},
 			// Egress rule for grafana-alloy
 			{
 				To: []networkingv1.NetworkPolicyPeer{

--- a/pkg/resourcegenerator/networkpolicy/dynamic/common.go
+++ b/pkg/resourcegenerator/networkpolicy/dynamic/common.go
@@ -180,29 +180,8 @@ func getIngressRules(accessPolicy *podtypes.AccessPolicy, ingresses []string, is
 		}
 	}
 
-	// Allow grafana-agent to scrape
+	// Allow grafana-alloy to scrape
 	if istioEnabled {
-		promScrapeRuleGrafana := networkingv1.NetworkPolicyIngressRule{
-			From: []networkingv1.NetworkPolicyPeer{
-				{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"kubernetes.io/metadata.name": GrafanaAgentNamespace},
-					},
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app.kubernetes.io/instance": GrafanaAgentName,
-							"app.kubernetes.io/name":     GrafanaAgentName,
-						},
-					},
-				},
-			},
-			Ports: []networkingv1.NetworkPolicyPort{
-				{
-					Port: util.PointTo(util.IstioMetricsPortName),
-				},
-			},
-		}
-
 		promScrapeRuleAlloy := networkingv1.NetworkPolicyIngressRule{
 			From: []networkingv1.NetworkPolicyPeer{
 				{
@@ -224,7 +203,6 @@ func getIngressRules(accessPolicy *podtypes.AccessPolicy, ingresses []string, is
 			},
 		}
 
-		ingressRules = append(ingressRules, promScrapeRuleGrafana)
 		ingressRules = append(ingressRules, promScrapeRuleAlloy)
 	}
 

--- a/pkg/resourcegenerator/networkpolicy/dynamic/network_policy.go
+++ b/pkg/resourcegenerator/networkpolicy/dynamic/network_policy.go
@@ -6,8 +6,6 @@ import (
 )
 
 const (
-	GrafanaAgentName      = "grafana-agent"
-	GrafanaAgentNamespace = GrafanaAgentName
 	AlloyAgentName        = "alloy"
 	AlloyAgentNamespace   = "grafana-alloy"
 )

--- a/tests/application/service-monitor/application-istio-assert.yaml
+++ b/tests/application/service-monitor/application-istio-assert.yaml
@@ -96,16 +96,6 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: grafana-agent
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/instance: grafana-agent
-              app.kubernetes.io/name: grafana-agent
-      ports:
-        - port: istio-metrics
-    - from:
-        - namespaceSelector:
-            matchLabels:
               kubernetes.io/metadata.name: grafana-alloy
           podSelector:
             matchLabels:

--- a/tests/application/service-monitor/application-simple-assert.yaml
+++ b/tests/application/service-monitor/application-simple-assert.yaml
@@ -85,16 +85,6 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: grafana-agent
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/instance: grafana-agent
-              app.kubernetes.io/name: grafana-agent
-      ports:
-        - port: istio-metrics
-    - from:
-        - namespaceSelector:
-            matchLabels:
               kubernetes.io/metadata.name: grafana-alloy
           podSelector:
             matchLabels:

--- a/tests/application/subresource-status/application-resource-apply-error-assert.yaml
+++ b/tests/application/subresource-status/application-resource-apply-error-assert.yaml
@@ -44,7 +44,7 @@ status:
       message: >-
         NetworkPolicy NetworkPolicy.networking.k8s.io "badport" is invalid:
         [spec.ingress[0].ports[0].port: Invalid value: 80801: must be between 1
-        and 65535, inclusive, spec.ingress[3].ports[0].port: Invalid value:
+        and 65535, inclusive, spec.ingress[2].ports[0].port: Invalid value:
         80801: must be between 1 and 65535, inclusive]
       status: Error
     PeerAuthentication[badport]:

--- a/tests/namespace/default-deny/assert.yaml
+++ b/tests/namespace/default-deny/assert.yaml
@@ -55,19 +55,6 @@ spec:
     to:
       - namespaceSelector:
           matchLabels:
-            kubernetes.io/metadata.name: grafana-agent
-        podSelector:
-          matchLabels:
-            app.kubernetes.io/instance: grafana-agent
-            app.kubernetes.io/name: grafana-agent
-  - ports:
-      - port: 4317
-        protocol: TCP
-      - port: 4318
-        protocol: TCP
-    to:
-      - namespaceSelector:
-          matchLabels:
             kubernetes.io/metadata.name: grafana-alloy
         podSelector:
           matchLabels:


### PR DESCRIPTION
Removes all old references to grafana-agent while keeping -alloy. Fixed test where needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated network policies to remove all ingress and egress rules that previously allowed access for Grafana Agent pods and namespaces. Only rules for Grafana Alloy remain.
  - Adjusted error reporting to reference the correct ingress rule index in network policy validation messages.

- **Tests**
  - Updated test cases to reflect the removal of Grafana Agent-related network policy rules, ensuring only Grafana Alloy access is permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->