### PR TITLE
Add feature flag to enable locally built images

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -15,12 +15,14 @@ var FeatureFlags *Features
 type Features struct {
 	DisablePodTopologySpreadConstraints bool
 	EnableProfiling                     bool
+	EnableLocallyBuiltImages            bool
 }
 
 func init() {
 	FeatureFlags = &Features{
 		DisablePodTopologySpreadConstraints: getEnvWithFallback("DISABLE_PTSC", false),
 		EnableProfiling:                     getEnvWithFallback("ENABLE_PROFILING", false),
+		EnableLocallyBuiltImages:            getEnvWithFallback("ENABLE_LOCAL_IMAGES", false),
 	}
 }
 

--- a/pkg/resourcegenerator/deployment/deployment.go
+++ b/pkg/resourcegenerator/deployment/deployment.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	goerrors "errors"
 	"fmt"
+	"github.com/kartverket/skiperator/pkg/flags"
 	"strings"
 
 	"github.com/kartverket/skiperator/pkg/reconciliation"
@@ -215,13 +216,16 @@ func Generate(r reconciliation.Reconciliation) error {
 		deployment.Annotations[AnnotationKeyLinkPrefix] = fmt.Sprintf("https://%s", ingresses[0])
 	}
 
-	err = util.ResolveImageTags(r.GetCtx(), ctxLog.GetLogger(), r.GetRestConfig(), &deployment)
-	if err != nil {
-		//TODO fix this
-		// Exclude dummy image used in tests for decreased verbosity
-		if !strings.Contains(err.Error(), "https://index.docker.io/v2/library/image/manifests/latest") {
-			ctxLog.Error(err, "could not resolve container image to digest")
-			return err
+	// Global feature flag
+	if !flags.FeatureFlags.EnableLocallyBuiltImages {
+		err = util.ResolveImageTags(r.GetCtx(), ctxLog.GetLogger(), r.GetRestConfig(), &deployment)
+		if err != nil {
+			//TODO fix this
+			// Exclude dummy image used in tests for decreased verbosity
+			if !strings.Contains(err.Error(), "https://index.docker.io/v2/library/image/manifests/latest") {
+				ctxLog.Error(err, "could not resolve container image to digest")
+				return err
+			}
 		}
 	}
 

--- a/pkg/resourcegenerator/pod/pod.go
+++ b/pkg/resourcegenerator/pod/pod.go
@@ -75,10 +75,17 @@ func CreatePodSpec(containers []corev1.Container, volumes []corev1.Volume, servi
 }
 
 func CreateApplicationContainer(application *skiperatorv1alpha1.Application, opts PodOpts) corev1.Container {
+	imagePullPolicy := func() corev1.PullPolicy {
+		if flags.FeatureFlags.EnableLocallyBuiltImages {
+			return corev1.PullNever
+		}
+		return corev1.PullAlways
+	}()
+
 	return corev1.Container{
 		Name:            application.Name,
 		Image:           application.Spec.Image,
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: imagePullPolicy,
 		Command:         application.Spec.Command,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged:               util.PointTo(false),


### PR DESCRIPTION
We would like the opportunity to run our locally built docker images in a Skiperator-application on a local kind-cluster. This PR adds a feature flag for this which disables resolving image tag for the deployment and sets the `imagePullPolicy`in the container to `Never`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to control support for locally built images.
  * When enabled, image pull policy is set to never pull images, and image tag resolution is skipped.

* **Behavior Changes**
  * Image pull and resolution logic now adapts based on the feature flag, allowing improved support for local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->