### PR TITLE
skip-1725: backoff limit

### DIFF
--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"dario.cat/mergo"
 	"github.com/kartverket/skiperator/api/v1alpha1/istiotypes"
 	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
 	batchv1 "k8s.io/api/batch/v1"
@@ -217,24 +216,28 @@ func (skipJob *SKIPJob) SetStatus(status SkiperatorStatus) {
 	skipJob.Status = status
 }
 
-func (skipJob *SKIPJob) FillDefaultSpec() error {
-	defaults := &SKIPJob{
-		Spec: SKIPJobSpec{
-			Job: &JobSettings{
-				TTLSecondsAfterFinished: &DefaultTTLSecondsAfterFinished,
-				BackoffLimit:            &DefaultBackoffLimit,
-				Suspend:                 &DefaultSuspend,
-			},
-		},
+func (skipJob *SKIPJob) FillDefaultSpec() {
+	if skipJob.Spec.Job == nil {
+		skipJob.Spec.Job = &JobSettings{}
+	}
+
+	if skipJob.Spec.Job.TTLSecondsAfterFinished == nil {
+		skipJob.Spec.Job.TTLSecondsAfterFinished = &DefaultTTLSecondsAfterFinished
+	}
+
+	if skipJob.Spec.Job.BackoffLimit == nil {
+		skipJob.Spec.Job.BackoffLimit = &DefaultBackoffLimit
+	}
+
+	if skipJob.Spec.Job.Suspend == nil {
+		skipJob.Spec.Job.Suspend = &DefaultSuspend
 	}
 
 	if skipJob.Spec.Cron != nil {
-		defaults.Spec.Cron = &CronSettings{}
-		suspend := false
-		defaults.Spec.Cron.Suspend = &suspend
+		if skipJob.Spec.Cron.Suspend == nil {
+			skipJob.Spec.Cron.Suspend = &DefaultSuspend
+		}
 	}
-
-	return mergo.Merge(skipJob, defaults)
 }
 
 // TODO we should test SKIPJob status better, same for Routing probably

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/kartverket/skiperator
 go 1.24.4
 
 require (
-	dario.cat/mergo v1.0.2
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/cert-manager/cert-manager v1.18.2
 	github.com/chmike/domain v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,6 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
-dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
-dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -217,9 +217,8 @@ func (r *SKIPJobReconciler) getSKIPJob(ctx context.Context, req reconcile.Reques
 }
 
 func (r *SKIPJobReconciler) setSKIPJobDefaults(ctx context.Context, skipJob *skiperatorv1alpha1.SKIPJob) error {
-	if err := skipJob.FillDefaultSpec(); err != nil {
-		return fmt.Errorf("error when trying to fill default spec: %w", err)
-	}
+	skipJob.FillDefaultSpec()
+
 	if !ctrlutil.ContainsFinalizer(skipJob, skipJobFinalizer) {
 		ctrlutil.AddFinalizer(skipJob, skipJobFinalizer)
 	}


### PR DESCRIPTION
previously did not differentiate between nil and 0 for backofflimit. without extensive knowledge of mergo it was easier to just set defaults the old school way. now explicit 0 for backofflimit is supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved reliability of default value assignment for jobs by updating how defaults are set.
  * Removed an external dependency to streamline the application.

* **Chores**
  * Cleaned up unused dependencies for a leaner codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->