### PR TITLE
SKIP-1759: TopologySpreadConstraint for cloud clusters

### DIFF
--- a/config/skiperator-config.yaml
+++ b/config/skiperator-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skiperator-config
+  namespace: skiperator-system
+data:
+  isCloudCluster: "false"

--- a/config/skiperator-config.yaml
+++ b/config/skiperator-config.yaml
@@ -4,4 +4,10 @@ metadata:
   name: skiperator-config
   namespace: skiperator-system
 data:
-  isCloudCluster: "false"
+  config.json: |
+    {
+      "topologyKeys": [
+        "kubernetes.io/hostname",
+        "onprem.gke.io/failure-domain-name"
+      ] 
+    }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,37 +2,72 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/kartverket/skiperator/pkg/util"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var IsCloudCluster bool
+const (
+	cmName      = "skiperator-config"
+	cmNamespace = "skiperator-system"
+	cmKey       = "config.json"
+)
+
+// SkiperatorConfig holds various configuration options for Skiperator that may differ across
+// environments or deployments (public cloud, local development or on-premises).
+//
+// TODO: Reduce other ways of configuring Skiperator, such as environment variables or flags and use this ConfigMap instead.
+type SkiperatorConfig struct {
+	TopologyKeys []string `json:"topologyKeys"`
+}
+
+var (
+	// ActiveConfig holds the currently loaded Skiperator configuration from external sources.
+	activeConfig SkiperatorConfig
+	mu           sync.Mutex
+)
 
 // LoadConfig loads the configuration once at startup
-func LoadConfig(client client.Client) error {
-	configMapNamespaced := types.NamespacedName{
-		Namespace: "skiperator-system",
-		Name:      "skiperator-config",
-	}
+func LoadConfig(ctx context.Context, c client.Client) error {
+	mu.Lock()
+	defer mu.Unlock()
 
-	configMap, err := util.GetConfigMap(client, context.Background(), configMapNamespaced)
+	cm, err := util.GetConfigMap(c, ctx, types.NamespacedName{Namespace: cmNamespace, Name: cmName})
 	if err != nil {
 		return fmt.Errorf("failed to load config ConfigMap: %w", err)
 	}
 
-	isCloudStr, exists := configMap.Data["isCloudCluster"]
-	if !exists {
-		return fmt.Errorf("isCloudCluster field not found in ConfigMap")
+	raw, ok := cm.Data[cmKey]
+	if !ok {
+		return fmt.Errorf("config ConfigMap missing key %q", cmKey)
 	}
-	isCloud, err := strconv.ParseBool(isCloudStr)
-	if err != nil {
-		return fmt.Errorf("invalid boolean value for isCloudCluster: %q: %w", isCloudStr, err)
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("config.json is present but empty")
 	}
-	IsCloudCluster = isCloud
+
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+
+	var cfg SkiperatorConfig
+	if err := dec.Decode(&cfg); err != nil {
+		return fmt.Errorf("failed to unmarshal ConfigMap data: %w", err)
+	}
+
+	// Set a default value for TopologyKeys if not set
+	if len(cfg.TopologyKeys) == 0 {
+		cfg.TopologyKeys = []string{"kubernetes.io/hostname"}
+	}
+
+	activeConfig = cfg
 
 	return nil
+}
+
+func GetActiveConfig() SkiperatorConfig {
+	return activeConfig
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/kartverket/skiperator/pkg/util"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var IsCloudCluster bool
+
+// LoadConfig loads the configuration once at startup
+func LoadConfig(client client.Client) error {
+	configMapNamespaced := types.NamespacedName{
+		Namespace: "skiperator-system",
+		Name:      "skiperator-config",
+	}
+
+	configMap, err := util.GetConfigMap(client, context.Background(), configMapNamespaced)
+	if err != nil {
+		return fmt.Errorf("failed to load config ConfigMap: %w", err)
+	}
+
+	isCloudStr, exists := configMap.Data["isCloudCluster"]
+	if !exists {
+		return fmt.Errorf("isCloudCluster field not found in ConfigMap")
+	}
+	isCloud, err := strconv.ParseBool(isCloudStr)
+	if err != nil {
+		return fmt.Errorf("invalid boolean value for isCloudCluster: %q: %w", isCloudStr, err)
+	}
+	IsCloudCluster = isCloud
+
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var emptyConfig = SkiperatorConfig{}
+
+func TestDefaultConfig(t *testing.T) {
+	cm := mockConfigMap(emptyConfig, nil)
+	err := parseConfig(cm)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(GetActiveConfig().TopologyKeys))
+	assert.Contains(t, GetActiveConfig().TopologyKeys, "kubernetes.io/hostname")
+}
+
+func TestCustomTopologyKeys(t *testing.T) {
+	cm := mockConfigMap(SkiperatorConfig{
+		TopologyKeys: []string{
+			"kubernetes.io/hostname",
+			"topology.kubernetes.io/zone",
+			"skip.kartverket.no/unit-test",
+		},
+	}, nil)
+	err := parseConfig(cm)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(GetActiveConfig().TopologyKeys))
+	assert.Contains(t, GetActiveConfig().TopologyKeys, "kubernetes.io/hostname")
+	assert.Contains(t, GetActiveConfig().TopologyKeys, "topology.kubernetes.io/zone")
+	assert.Contains(t, GetActiveConfig().TopologyKeys, "skip.kartverket.no/unit-test")
+}
+
+func TestUnknownKey(t *testing.T) {
+	cm := mockConfigMap(emptyConfig, map[string]any{
+		"someUnknownKey": "someValue",
+	})
+	err := parseConfig(cm)
+
+	assert.Error(t, err)
+}
+
+func TestBadlyFormattedConfig(t *testing.T) {
+	cases := []struct {
+		name              string
+		topologyKeysValue any
+	}{
+		{"string", "it-should-be-an-array"},
+		{"number", 42},
+		{"boolean", true},
+		{"array-of-boolean", []bool{true, false}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cm := mockConfigMap(emptyConfig, map[string]any{
+				"topologyKeys": tc.topologyKeysValue,
+			})
+			err := parseConfig(cm)
+
+			assert.Error(t, err, "Expected error for topologyKeys with value: %v", tc.topologyKeysValue)
+		})
+	}
+}
+
+func mockConfigMap(c SkiperatorConfig, extra map[string]any) *v1.ConfigMap {
+	jsonPayload, _ := json.Marshal(c)
+
+	if extra != nil {
+		var dump map[string]any
+		_ = json.Unmarshal(jsonPayload, &dump)
+		for k, v := range extra {
+			dump[k] = v
+		}
+		jsonPayload, _ = json.Marshal(dump)
+	}
+
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: cmNamespace,
+		},
+		Data: map[string]string{
+			cmKey: string(jsonPayload),
+		},
+	}
+}

--- a/internal/config/skipcluster.go
+++ b/internal/config/skipcluster.go
@@ -3,10 +3,11 @@ package config
 import (
 	"context"
 	"errors"
+	"net"
+
 	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"net"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -30,7 +31,7 @@ func (c *SKIPClusterList) CombinedCIDRS() []string {
 	return combinedCIDRs
 }
 
-func LoadConfigFromConfigMap(client client.Client) (*SKIPClusterList, error) {
+func LoadSKIPClusterConfigFromConfigMap(client client.Client) (*SKIPClusterList, error) {
 	clusterConfigMapNamespaced := types.NamespacedName{Namespace: "skiperator-system", Name: "skip-cluster-node-cidr"}
 	clusterConfigMap, err := util.GetConfigMap(client, context.Background(), clusterConfigMapNamespaced)
 	if err != nil {

--- a/internal/config/skipclusters_test.go
+++ b/internal/config/skipclusters_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestValidConfigMap(t *testing.T) {

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -3,6 +3,9 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
+
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/api/v1alpha1/digdirator"
@@ -49,7 +52,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"regexp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +60,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strings"
 )
 
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=applications;applications/status,verbs=get;list;watch;update
@@ -338,7 +339,7 @@ func (r *ApplicationReconciler) setApplicationResourcesDefaults(resources []clie
 
 	//TODO should try to combine this with the above
 	resourceLabelsWithNoMatch := resourceutils.FindResourceLabelErrors(app, resources)
-	for k, _ := range resourceLabelsWithNoMatch {
+	for k := range resourceLabelsWithNoMatch {
 		r.EmitWarningEvent(app, "MistypedLabel", fmt.Sprintf("Resource label %s not a generated resource", k))
 	}
 	return nil

--- a/pkg/reconciliation/application.go
+++ b/pkg/reconciliation/application.go
@@ -2,6 +2,7 @@ package reconciliation
 
 import (
 	"context"
+
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/auth"
 	"github.com/kartverket/skiperator/pkg/log"

--- a/pkg/reconciliation/reconciliation.go
+++ b/pkg/reconciliation/reconciliation.go
@@ -2,6 +2,7 @@ package reconciliation
 
 import (
 	"context"
+
 	"github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/auth"
 	"github.com/kartverket/skiperator/pkg/log"

--- a/pkg/resourcegenerator/deployment/deployment.go
+++ b/pkg/resourcegenerator/deployment/deployment.go
@@ -3,9 +3,9 @@ package deployment
 import (
 	goerrors "errors"
 	"fmt"
-	"github.com/kartverket/skiperator/pkg/flags"
 	"strings"
 
+	"github.com/kartverket/skiperator/pkg/flags"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/idporten"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/maskinporten"

--- a/pkg/resourcegenerator/pod/pod.go
+++ b/pkg/resourcegenerator/pod/pod.go
@@ -8,24 +8,13 @@ import (
 	"github.com/kartverket/skiperator/internal/config"
 	"github.com/kartverket/skiperator/pkg/flags"
 	"github.com/kartverket/skiperator/pkg/util"
+	"github.com/kartverket/skiperator/pkg/util/array"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type SkiperatorTopologyKey string
-
 const (
-	// Hostname is the value populated by the Kubelet.
-	Hostname SkiperatorTopologyKey = "kubernetes.io/hostname"
-	// OnPremFailureDomain is populated to the underlying ESXi hostname by the GKE on VMware tooling.
-	OnPremFailureDomain SkiperatorTopologyKey = "onprem.gke.io/failure-domain-name"
-	// CloudZone spreads pods across availability zones
-	CloudZone SkiperatorTopologyKey = "topology.kubernetes.io/zone"
-)
-
-const (
-	// DefaultCloudSQLProxyVersion
 	DefaultCloudSQLProxyVersion = "2.15.1"
 )
 
@@ -70,16 +59,14 @@ func CreatePodSpec(containers []corev1.Container, volumes []corev1.Volume, servi
 	if !flags.FeatureFlags.DisablePodTopologySpreadConstraints {
 		// Allow override per application
 		if !podSettings.DisablePodSpreadTopologyConstraints {
-			// Choose topology key based on cluster type from global config
-			failureDomainKey := OnPremFailureDomain
-			if config.IsCloudCluster {
-				failureDomainKey = CloudZone
+			keys := array.TrimmedUniqueStrings(config.GetActiveConfig().TopologyKeys)
+			constraints := make([]corev1.TopologySpreadConstraint, 0, len(keys))
+
+			for _, topologyKey := range keys {
+				constraints = append(constraints, spreadConstraintForAppAndKey(serviceName, topologyKey))
 			}
 
-			p.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
-				spreadConstraintForAppAndKey(serviceName, Hostname),
-				spreadConstraintForAppAndKey(serviceName, failureDomainKey),
-			}
+			p.TopologySpreadConstraints = constraints
 		}
 	}
 
@@ -300,10 +287,10 @@ func getContainerPorts(application *skiperatorv1alpha1.Application, opts PodOpts
 	return containerPorts
 }
 
-func spreadConstraintForAppAndKey(appName string, key SkiperatorTopologyKey) corev1.TopologySpreadConstraint {
+func spreadConstraintForAppAndKey(appName string, key string) corev1.TopologySpreadConstraint {
 	return corev1.TopologySpreadConstraint{
 		MaxSkew:           1,
-		TopologyKey:       string(key),
+		TopologyKey:       key,
 		WhenUnsatisfiable: corev1.ScheduleAnyway,
 		LabelSelector: &v1.LabelSelector{
 			MatchExpressions: []v1.LabelSelectorRequirement{

--- a/pkg/resourceprocessor/diffs_test.go
+++ b/pkg/resourceprocessor/diffs_test.go
@@ -2,6 +2,8 @@ package resourceprocessor
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/log"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
@@ -10,7 +12,6 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +68,9 @@ func TestGetDiffForApplicationShouldCreateDelete(t *testing.T) {
 
 	// Create the live resource in the fake client
 	err := mockClient.Create(ctx, liveDeploymentDontDelete)
+	assert.Nil(t, err)
 	err = mockClient.Create(ctx, liveDeploymentIgnorePatchOrCreate)
+	assert.Nil(t, err)
 	err = mockClient.Create(ctx, liveSA)
 	assert.Nil(t, err)
 	r := reconciliation.NewApplicationReconciliation(context.TODO(), application, log.NewLogger(), false, nil, nil, nil)

--- a/pkg/util/array/main.go
+++ b/pkg/util/array/main.go
@@ -1,5 +1,10 @@
 package array
 
+import (
+	"slices"
+	"strings"
+)
+
 func MapErr[F any, T any](arr []F, transformFunc func(F) (T, error)) ([]T, error) {
 	var err error
 
@@ -12,4 +17,23 @@ func MapErr[F any, T any](arr []F, transformFunc func(F) (T, error)) ([]T, error
 	}
 
 	return res, nil
+}
+
+func TrimmedUniqueStrings(input []string) []string {
+	for i := range input {
+		input[i] = strings.TrimSpace(input[i])
+	}
+
+	return UniqueValues(input)
+}
+
+func UniqueValues[T comparable](input []T) []T {
+	uniqueSlice := []T{}
+	for _, val := range input {
+		if !slices.Contains(uniqueSlice, val) {
+			uniqueSlice = append(uniqueSlice, val)
+		}
+	}
+
+	return uniqueSlice
 }

--- a/samples/skiperator-config.yaml
+++ b/samples/skiperator-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skiperator-cluster-config
+  namespace: skiperator-system
+data:
+  isCloudCluster: "true"

--- a/samples/skiperator-config.yaml
+++ b/samples/skiperator-config.yaml
@@ -1,7 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: skiperator-cluster-config
+  name: skiperator-config
   namespace: skiperator-system
 data:
-  isCloudCluster: "true"
+  config.json: |
+    {
+      "topologyKeys": [
+        "kubernetes.io/hostname",
+        "onprem.gke.io/failure-domain-name"
+      ]
+    }


### PR DESCRIPTION
https://kartverket.atlassian.net/browse/SKIP-1759

- new required config map
- rename cluster config func
- linter and fmt fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runtime-configurable topology keys for Pod topology spread; conditional cluster config loading when cluster-aware behavior is enabled.
- **Improvements**
  - Early, time-limited global config loading at startup with fail-fast behavior and clearer startup logging; stricter setup error handling.
- **Documentation**
  - Added sample and default ConfigMap manifests to configure topology keys and cluster settings.
- **Tests**
  - New unit tests for config parsing and strengthened assertions.
- **Style**
  - Minor import/format cleanups and helper utilities for trimmed/unique arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->