### PR TITLE
Preserve Reloader annotation for workloads

### DIFF
--- a/pkg/resourcegenerator/resourceutils/metadata.go
+++ b/pkg/resourcegenerator/resourceutils/metadata.go
@@ -19,6 +19,8 @@ var (
 	}
 
 	AnnotationKeyLinkPrefix = "link.argocd.argoproj.io/external-link"
+
+	AnnotationKeyReloaderLastReloadedFrom = "reloader.stakater.com/last-reloaded-from"
 )
 
 func SetCommonAnnotations(object client.Object) {

--- a/pkg/resourceprocessor/resource.go
+++ b/pkg/resourceprocessor/resource.go
@@ -3,9 +3,11 @@ package resourceprocessor
 import (
 	"maps"
 
+	"github.com/kartverket/skiperator/pkg/resourcegenerator/resourceutils"
 	"github.com/kartverket/skiperator/pkg/util"
 	v1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -50,6 +52,8 @@ func preparePatch(new client.Object, old client.Object) {
 		// rollouts of different replicasets. This annotation must not trigger a new reconcile, and a quick and easy
 		// fix is to just remove it from the map before hashing and checking the diff.
 		delete(deployment.Spec.Template.Annotations, "kubectl.kubernetes.io/restartedAt")
+
+		preserveReloaderState(&definition.Spec.Template, &deployment.Spec.Template)
 	case *v1.StatefulSet:
 		sts := old.(*v1.StatefulSet)
 		definition := new.(*v1.StatefulSet)
@@ -63,6 +67,8 @@ func preparePatch(new client.Object, old client.Object) {
 
 		// same kubectl rollout restart annotation handling as for Deployment
 		delete(sts.Spec.Template.Annotations, "kubectl.kubernetes.io/restartedAt")
+
+		preserveReloaderState(&definition.Spec.Template, &sts.Spec.Template)
 	case *batchv1.Job:
 		job := old.(*batchv1.Job)
 		definition := new.(*batchv1.Job)
@@ -70,6 +76,21 @@ func preparePatch(new client.Object, old client.Object) {
 		definition.Spec.Selector = job.Spec.Selector                         // immutable
 		definition.Spec.Template = job.Spec.Template                         // immutable
 		definition.Spec.Completions = job.Spec.Completions                   // immutable
+	}
+}
+
+// preserveReloaderState ensures relevant Stakater Reloader state is copied from the live workload to the generated
+// workload, if present.
+//
+// Only reload-strategy=annotations is supported, for which resourceutils.AnnotationKeyReloaderLastReloadedFrom must be
+// preserved. To support reload-strategy=env-vars, this method must be expanded to preserve the dummy env vars Reloader
+// sets when using this strategy.
+func preserveReloaderState(desired, live *corev1.PodTemplateSpec) {
+	if lastReloadedFrom, ok := live.Annotations[resourceutils.AnnotationKeyReloaderLastReloadedFrom]; ok {
+		if desired.Annotations == nil {
+			desired.Annotations = make(map[string]string)
+		}
+		desired.Annotations[resourceutils.AnnotationKeyReloaderLastReloadedFrom] = lastReloadedFrom
 	}
 }
 

--- a/pkg/resourceprocessor/resource_test.go
+++ b/pkg/resourceprocessor/resource_test.go
@@ -1,10 +1,12 @@
 package resourceprocessor
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRequirePatch(t *testing.T) {
@@ -16,4 +18,27 @@ func TestRequirePatch(t *testing.T) {
 
 	assert.True(t, deplShouldPatch)
 	assert.False(t, saShouldPatch)
+}
+
+func TestPreserveReloaderStateKeepsAnnotationStrategyMarker(t *testing.T) {
+	live := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"reloader.stakater.com/last-reloaded-from": `[{"type":"SECRET","name":"azure-app","hash":"some-hash"}]`,
+				"prometheus.io/scrape":                     "true",
+			},
+		},
+	}
+	desired := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"prometheus.io/scrape": "true"},
+		},
+	}
+
+	preserveReloaderState(desired, live)
+
+	assert.Equal(t,
+		`[{"type":"SECRET","name":"azure-app","hash":"some-hash"}]`,
+		desired.Annotations["reloader.stakater.com/last-reloaded-from"],
+	)
 }


### PR DESCRIPTION
Reloader handles restart of workloads based on changes to secrets or configmaps. We want to offer this as functionality on SKIP. We have decided to use reload-strategy=annotations, which means Reloader will set an annotation on the workload to trigger rollout of new pods.

Currently, because Skiperator owns the deployment, whenever Reloader adds this annotation, Skiperator immediately runs reconcile for the corresponding Skiperator Application, and removes the annotation.

Our intention (for now) is that teams opt-in to use Reloader for their workload through the podSettings->annotations field in the Skiperator spec. There is no need for Skiperator to explicitly add this annotation to workloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- Preserve Reloader’s `reloader.stakater.com/last-reloaded-from` annotation during `Deployment` and `StatefulSet` reconciliation when using `reload-strategy=annotations`.
- Add test coverage for annotation preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->