### PR TITLE
SKIP-1889: Reconcile access policies when the target applications appears or is deleted

### DIFF
--- a/doc/improvements.md
+++ b/doc/improvements.md
@@ -95,12 +95,12 @@ already flags the code as wrong.
 
 ### E4. `perf` — scope the SKIPJob fan-out to one namespace
 
-[skipjob.go:95](../internal/controllers/skipjob.go:95) watches every
+[skipjob.go:101](../internal/controllers/skipjob.go:101) watches every
 NetworkPolicy in the cluster.
-[skipjob.go:301](../internal/controllers/skipjob.go:301) then lists **every**
+[skipjob.go:347](../internal/controllers/skipjob.go:347) then lists **every**
 SKIPJob in the cluster and enqueues all of them.
 
-A guard at [skipjob.go:296](../internal/controllers/skipjob.go:296) limits this to
+A guard at [skipjob.go:343](../internal/controllers/skipjob.go:343) limits this to
 NetworkPolicies owned by an Application, so it does not fire on every event.
 When it does fire with `MaxConcurrentReconciles: 1`, one access-policy edit
 serializes a full-fleet sweep.
@@ -110,7 +110,7 @@ Action: add `client.InNamespace(object.GetNamespace())` to the List.
 ### E5. `perf` — set `MaxConcurrentReconciles` on the other three controllers
 
 Only the Application controller wires the value, at
-[application.go:140](../internal/controllers/application.go:140). The Routing,
+[application.go:151](../internal/controllers/application.go:151). The Routing,
 SKIPJob, and Namespace controllers call `.Complete(r)` with no
 `WithOptions`, so they run one worker each.
 
@@ -124,10 +124,10 @@ the three controllers, so the setting means the same thing everywhere.
 
 ### E6. `perf` — check the ServiceMonitor CRD once, not once per reconcile
 
-[application.go:507](../internal/controllers/application.go:507) runs an
+[application.go:527](../internal/controllers/application.go:527) runs an
 uncached GET against the apiextensions API on every Application reconcile. A
 failure calls `panic` at
-[application.go:156](../internal/controllers/application.go:156).
+[application.go:167](../internal/controllers/application.go:167).
 
 The Gateway API CRDs already use the correct pattern: one check at startup, at
 [main.go:337](../cmd/skiperator/main.go:337).
@@ -163,7 +163,7 @@ Action: remove the `DeepCopyObject` call. Preallocate with `len(schema.Items)`.
 
 ### E9. `perf` — hoist the ingress-gateway regular expression
 
-[application.go:569](../internal/controllers/application.go:569) calls
+[application.go:614](../internal/controllers/application.go:614) calls
 `regexp.MatchString("^.*-ingress-.*$", gateway.Name)` for every Istio Gateway
 event. The same file already shows the correct pattern at
 [application.go:102](../internal/controllers/application.go:102), with
@@ -241,9 +241,9 @@ Action: delete the function and its call.
 `ResourceProcessor.Process` returns `[]error` at
 [processor.go:28](../pkg/resourceprocessor/processor.go:28). All three controllers
 collapse it to `fmt.Errorf("found %d errors", len(errs))`, at
-[application.go:353](../internal/controllers/application.go:353),
+[application.go:364](../internal/controllers/application.go:364),
 [routing.go:223](../internal/controllers/routing.go:223), and
-[skipjob.go:224](../internal/controllers/skipjob.go:224). The error text loses
+[skipjob.go:234](../internal/controllers/skipjob.go:234). The error text loses
 every cause.
 
 Action: return `errors.Join(errs...)`.
@@ -269,7 +269,7 @@ is archived. `fmt.Errorf` with the `%w` verb replaces it.
 
 ### E17. `delete` — remove the stale requeue comment
 
-[util.go:27](../internal/controllers/common/util.go:27) says
+[util.go:28](../internal/controllers/common/util.go:28) says
 `// TODO: exponential backoff`. Controller-runtime already applies exponential
 backoff, from 5 ms to 1000 s, to a reconcile that returns an error.
 
@@ -291,14 +291,14 @@ that is worth setting.
 
 ### E19. `perf` — make the workload predicates cheap, and drop a dependency
 
-[predicates.go:26](../internal/controllers/common/predicates.go:26) and
-[predicates.go:48](../internal/controllers/common/predicates.go:48) run, per
+[predicates.go:52](../internal/controllers/common/predicates.go:52) and
+[predicates.go:61](../internal/controllers/common/predicates.go:61) run, per
 Deployment or StatefulSet event: two `DeepCopyObject` calls, then two
 `hashstructure.Hash` reflection walks over a whole PodSpec.
 
 The predicate itself is **correct and load-bearing**. It masks
 `Spec.Replicas` so that HPA scaling does not start a reconcile. Keep that.
-The comment at [predicates.go:39](../internal/controllers/common/predicates.go:39)
+The comment at [predicates.go:52](../internal/controllers/common/predicates.go:52)
 records the accepted trade-off, that a manual replica edit no longer
 reconciles. Keep that too.
 
@@ -332,6 +332,40 @@ earlier optimization pass. The numbers are useful. Their location is not.
 Action: move both into `doc/` as a baseline record.
 
 ---
+
+### E21. `perf` — use field indexes in the remaining map functions
+
+A map function that answers "which objects depend on this one" has an upstream
+tool: a field index, registered with `mgr.GetFieldIndexer().IndexField` and read
+with `client.MatchingFields`. The lookup is served from the cache. The
+repository has one index, `OutboundTargetIndex` at
+[util.go:55](../internal/controllers/common/util.go:55). The other map functions
+list a kind and filter in memory, or do not filter at all.
+
+[routing.go:461](../internal/controllers/routing.go:461) lists every Routing in
+the namespace of the changed Application and enqueues all of them. A Routing
+names its applications in `spec.routes[].targetApp`, so an index on that field
+returns only the Routings that reference the object that changed.
+
+[skipjob.go:347](../internal/controllers/skipjob.go:347) lists every SKIPJob in
+the cluster and enqueues all of them. E4 narrows it to one namespace, which is
+the cheaper first step. The dependency behind this watch is not documented. A
+SKIPJob derives its network policies from its own access policy. The Service
+watch on each controller now covers a target that appears or is deleted.
+Establish what the watch is for before you index it. It can be redundant.
+
+[conflicts.go](../pkg/gwapi/conflicts.go) runs three unfiltered cluster-wide
+Lists per reconcile. B14 covers those.
+
+Action: register the index in `SetupWithManager`, then query it with
+`client.MatchingFields`.
+[application.go:105](../internal/controllers/application.go:105) is a worked
+example, and two rules from it carry over. First, keep the index function pure.
+It runs inside the informer, where a panic stops the process, so it must not
+call an accessor that assumes a defaulted field. Second, index the narrowest key
+that cannot miss a dependent. The key of `OutboundTargetIndex` is the
+application name and not the namespace, because a rule can select namespaces by
+label. A redundant reconcile costs less than a lookup.
 
 ## Bigger tasks
 
@@ -442,9 +476,9 @@ field. No namespace, label, or field restriction exists anywhere in the
 repository.
 
 Cached cluster-wide today: **every Secret** (from
-[application.go:129](../internal/controllers/application.go:129) and
+[application.go:136](../internal/controllers/application.go:136) and
 [namespace.go:44](../internal/controllers/namespace.go:44)) and **every
-ConfigMap** (from [application.go:110](../internal/controllers/application.go:110)),
+ConfigMap** (from [application.go:117](../internal/controllers/application.go:117)),
 plus about 25 other kinds.
 
 Across 500 namespaces this holds every service-account token, every Helm
@@ -453,7 +487,7 @@ on the heap.
 
 The consumers are already narrow. The Secret map function wants only
 `type` containing `digdirator.nais.io`, at
-[application.go:533](../internal/controllers/application.go:533). The Namespace
+[application.go:578](../internal/controllers/application.go:578). The Namespace
 controller wants only `github-auth`.
 
 Action:
@@ -465,12 +499,12 @@ Action:
 
 ### B4. `perf` — make Gateway API readiness event-driven
 
-[application.go:358](../internal/controllers/application.go:358) and
+[application.go:369](../internal/controllers/application.go:369) and
 [routing.go:234](../internal/controllers/routing.go:234) return
 `RequeueAfter: 10 * time.Second` while standard routing is not ready.
 
 The polling loop is load-bearing, not decorative. The event filter at
-[application.go:131](../internal/controllers/application.go:131) uses
+[application.go:142](../internal/controllers/application.go:142) uses
 `predicate.Or(GenerationChangedPredicate{}, LabelChangedPredicate{})`. That
 filter drops status-only updates on ListenerSet, HTTPRoute, and Certificate.
 Those updates are the ones that report readiness.
@@ -494,11 +528,11 @@ Two problems compound here.
 
 **Two status writes per reconcile.** `SetProgressingState` writes status
 before any work happens, at
-[application.go:265](../internal/controllers/application.go:265), through a
+[application.go:276](../internal/controllers/application.go:276), through a
 `RetryOnConflict` loop that adds its own GET, at
 [reconciler.go:171](../internal/controllers/common/reconciler.go:171). The
 terminal path writes again at
-[application.go:378](../internal/controllers/application.go:378). The same shape
+[application.go:398](../internal/controllers/application.go:398). The same shape
 appears in `routing.go:132` and `skipjob.go:174`.
 
 **Every status value changes every reconcile.** `Status.TimeStamp` is set from
@@ -509,7 +543,7 @@ appears in `routing.go:132` and `skipjob.go:174`.
 
 The second problem produced the workaround for the first.
 `filterOutStatusTimestamps`, at
-[util.go:188](../internal/controllers/common/util.go:188), exists to hide the
+[util.go:246](../internal/controllers/common/util.go:246), exists to hide the
 churn that the operator itself creates, and it needs a whole diffing library
 to do it.
 
@@ -522,7 +556,7 @@ Action:
    dependency `github.com/r3labs/diff/v3` goes away.
 
 `GetObjectDiff` is also worth reading on its own, at
-[util.go:171](../internal/controllers/common/util.go:171). Its guard compares
+[util.go:211](../internal/controllers/common/util.go:211). Its guard compares
 `reflect.Kind` of two values of the same type parameter, so the guard can never
 fire. Four of its five callers only test `len(diff) > 0`.
 
@@ -535,9 +569,9 @@ body is a map lookup.
 
 The lookup re-derives a fact that the compiler already knows. The controllers
 build type-specific slices at
-[application.go:292](../internal/controllers/application.go:292),
+[application.go:303](../internal/controllers/application.go:303),
 [routing.go:185](../internal/controllers/routing.go:185), and
-[skipjob.go:185](../internal/controllers/skipjob.go:185). An Application-only
+[skipjob.go:195](../internal/controllers/skipjob.go:195). An Application-only
 slice already names `certificate.Generate`.
 
 The codebase now has three dispatch styles for one job. `defaultdeny` and
@@ -606,13 +640,13 @@ Each of the three controllers holds its own copy of the same five blocks.
 | `cleanUpWatchedResources`                                                                  | 2      | 10    |
 
 `updateApplicationStatus` at
-[application.go:381](../internal/controllers/application.go:381) is a retype of
+[application.go:401](../internal/controllers/application.go:401) is a retype of
 `ReconcilerBase.UpdateStatus` at
 [reconciler.go:166](../internal/controllers/common/reconciler.go:166).
 `Application` already satisfies `common.SKIPObject`.
 
 Four near-identical SKIPJob condition constructors at
-[skipjob.go:316](../internal/controllers/skipjob.go:316) reduce to one closure and
+[skipjob.go:362](../internal/controllers/skipjob.go:362) reduce to one closure and
 a four-row table.
 
 ### B10. `shrink` — one generic guard for the generators
@@ -887,7 +921,7 @@ source as ugly at [diffs.go:29](../pkg/resourceprocessor/diffs.go:29).
 
 **4. The ignore label is implemented twice.**
 Once for events, in `common.ShouldReconcile` at
-[util.go:32](../internal/controllers/common/util.go:32). Once for diffing, in
+[util.go:33](../internal/controllers/common/util.go:33). Once for diffing, in
 `shouldIgnoreObject` at [diffs.go:111](../pkg/resourceprocessor/diffs.go:111).
 Both call the same metrics functions.
 
@@ -1164,7 +1198,7 @@ Benchmarks worth writing, with `-benchmem`:
   the JSON marshal, and the SHA-256, twice per object.
 - `BenchmarkDeploymentPredicate` with a real `event.UpdateEvent`. Measures two
   `DeepCopyObject` calls and two `hashstructure.Hash` reflection walks per
-  Deployment event, at [predicates.go:32](../internal/controllers/common/predicates.go:32).
+  Deployment event, at [predicates.go:45](../internal/controllers/common/predicates.go:45).
 - `BenchmarkGetObjectDiff` on a populated `ApplicationSpec`, against
   `equality.Semantic.DeepEqual`.
 
@@ -1175,7 +1209,8 @@ Benchmarks worth writing, with `-benchmem`:
 1. **B15** — golden-file tests over the generators. Do this **first**. It is
    the safety net that makes everything below cheap to attempt, and it is the
    one thing naiserator already proves works.
-2. **E1, E2, E3, E4, E6** — five small perf fixes, no design decision needed.
+2. **E1, E2, E3, E4, E6, E21** — six small perf fixes, no design decision
+   needed. Do E4 before E21: it is the cheaper half of the same finding.
 3. **B1** — typed lists. The largest immediate win. Measure with the
    ratio in the table above.
 4. **B3** — cache selectors and a transform. The largest memory win. About 20

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -102,6 +102,13 @@ const applicationFinalizer = "skip.statkart.no/finalizer"
 var hostMatchExpression = regexp.MustCompile(`^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$`)
 
 func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager, concurrentReconciles int) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &skiperatorv1alpha1.Application{},
+		common.OutboundTargetIndex, func(obj client.Object) []string {
+			return common.OutboundTargets(obj.(*skiperatorv1alpha1.Application).Spec.AccessPolicy)
+		}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&skiperatorv1alpha1.Application{}).
 		Owns(&appsv1.Deployment{}, builder.WithPredicates(common.DeploymentPredicate)).
@@ -128,6 +135,10 @@ func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager, concurrentRec
 		Owns(&gatewayapiv1.HTTPRoute{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(handleDigdiratorSecret)).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(handleApplicationCertRequest)).
+		// An outbound rule stays unresolved until the Service of the target
+		// application exists. Dependent objects therefore reconcile as soon as
+		// that Service appears or is deleted, and not at the next periodic requeue.
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.outboundTargetRequests)).
 		WithEventFilter(
 			predicate.And(
 				common.DefaultPredicate, // Runs first
@@ -356,7 +367,16 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 
 	r.setSyncedApplicationState(ctx, application, "Application has been reconciled", routingState)
 	if application.Status.AccessPolicies == skiperatorv1alpha1.INVALIDCONFIG {
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		// Internal rules take their ports from the Service of the target
+		// application, so they can become valid with no change to this spec.
+		// The Service watch covers a target that appears or is deleted. This
+		// poll covers only the cases that no watch reports. External rules
+		// depend on the spec alone, so there is nothing to wait for and the
+		// reconcile stops until the spec changes.
+		if !common.IsInternalRulesValid(application.Spec.AccessPolicy) {
+			return reconcile.Result{RequeueAfter: common.AccessPolicyRequeueDelay}, nil
+		}
+		return common.DoNotRequeue()
 	}
 	if application.UsesStandardRouting() && !routingState.Readiness.Ready {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -522,6 +542,28 @@ func (r *ApplicationReconciler) teamNameForNamespace(ctx context.Context, app *s
 		return teamValue, nil
 	}
 	return "", fmt.Errorf("missing value for team label")
+}
+
+// outboundTargetRequests maps a changed Service to the Applications whose outbound
+// rules target it. The ports of an outbound rule come from the Service of the
+// target application (see setPortsForRules). A dependent object stays in
+// InvalidConfig until that Service exists, and must reconcile as soon as the
+// Service appears or is deleted.
+func (r *ApplicationReconciler) outboundTargetRequests(ctx context.Context, service client.Object) []reconcile.Request {
+	dependents := &skiperatorv1alpha1.ApplicationList{}
+	if err := r.GetClient().List(ctx, dependents, client.MatchingFields{common.OutboundTargetIndex: service.GetName()}); err != nil {
+		r.Logger.Error(err, "failed to list Applications that target a Service",
+			"service", client.ObjectKeyFromObject(service))
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(dependents.Items))
+	for i := range dependents.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&dependents.Items[i]),
+		})
+	}
+	return requests
 }
 
 func handleDigdiratorSecret(_ context.Context, obj client.Object) []reconcile.Request {

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -355,6 +355,9 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	}
 
 	r.setSyncedApplicationState(ctx, application, "Application has been reconciled", routingState)
+	if application.Status.AccessPolicies == skiperatorv1alpha1.INVALIDCONFIG {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
 	if application.UsesStandardRouting() && !routingState.Readiness.Ready {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}

--- a/internal/controllers/common/predicates.go
+++ b/internal/controllers/common/predicates.go
@@ -10,11 +10,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// DefaultPredicate limits Create events to the types that skiperator reacts to.
+// The subresources that skiperator creates itself do not start a second
+// reconcile. corev1.Service is in the list because the ports of an outbound
+// access policy come from the Service of the target application. A new Service
+// is therefore the signal that unblocks every object that references it (see
+// OutboundTargets).
+//
+// The controller installs this predicate through WithEventFilter, so it applies
+// to every watch. A type must appear in the list below, or its Create events
+// never reach the reconciler. A predicate per watch through
+// builder.WithPredicates is more precise, but then every Owns() call needs a
+// predicate of its own.
 var DefaultPredicate = predicate.Funcs{
 	CreateFunc: func(e event.CreateEvent) bool {
 		switch e.Object.(type) {
 		case *skiperatorv1alpha1.Application,
 			*corev1.Secret,
+			*corev1.Service,
 			*certmanagerv1.Certificate:
 			return true
 		default:

--- a/internal/controllers/common/util.go
+++ b/internal/controllers/common/util.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/chmike/domain"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -43,6 +44,45 @@ func ShouldReconcile(obj client.Object) bool {
 
 func IsNamespaceTerminating(namespace *corev1.Namespace) bool {
 	return namespace.Status.Phase == corev1.NamespaceTerminating
+}
+
+// OutboundTargetIndex is the field index that Application and SKIPJob
+// register on the applications their outbound rules target. The index maps a
+// changed Service back to its dependents. Without it, each Service event must
+// list every object.
+//
+// Inbound rules need no index. They compile to label selectors that Kubernetes
+// evaluates, so the operator has nothing to recompute when a peer appears.
+const OutboundTargetIndex = "accessPolicy.outbound.rules.application"
+
+// AccessPolicyRequeueDelay is how often an object with unresolved internal
+// rules reconciles again. The Service watch on each controller covers a target
+// Service that appears or is deleted. This delay covers the two
+// cases that no watch reports. A target Service can gain ports, and a namespace
+// can gain a label that a rule selects on.
+const AccessPolicyRequeueDelay = 5 * time.Minute
+
+// OutboundTargets lists the applications that the outbound rules target,
+// for use as index values. The namespace is not part of the key. Rules can
+// select namespaces by label, and that set of namespaces needs a lookup. A key
+// of the name alone selects too many objects, but it never misses a dependent.
+// A reconcile is idempotent, so a redundant one costs less than the lookup.
+//
+// This function takes the access policy and not a client.Object, so that it
+// stays pure and has no panic path of its own. An index function runs inside the informer,
+// where a panic stops the process. The spec accessors on Application and
+// SKIPJob read fields that the API server defaults. An object built in memory
+// does not have those defaults.
+func OutboundTargets(accessPolicy *podtypes.AccessPolicy) []string {
+	if accessPolicy == nil || accessPolicy.Outbound == nil {
+		return nil
+	}
+
+	targets := make([]string, len(accessPolicy.Outbound.Rules))
+	for i, rule := range accessPolicy.Outbound.Rules {
+		targets[i] = rule.Application
+	}
+	return targets
 }
 
 func IsInternalRulesValid(accessPolicy *podtypes.AccessPolicy) bool {

--- a/internal/controllers/common/util_test.go
+++ b/internal/controllers/common/util_test.go
@@ -264,3 +264,33 @@ func TestValidateContainerImageString(t *testing.T) {
 		}))
 	})
 }
+
+func outboundPolicyTo(applications ...string) *podtypes.AccessPolicy {
+	rules := make([]podtypes.InternalRule, len(applications))
+	for i, application := range applications {
+		rules[i] = podtypes.InternalRule{Application: application}
+	}
+	return &podtypes.AccessPolicy{
+		Outbound: &podtypes.OutboundPolicy{
+			Rules: rules,
+		},
+	}
+}
+
+func TestOutboundTargets(t *testing.T) {
+	tests := map[string]struct {
+		accessPolicy *podtypes.AccessPolicy
+		expected     []string
+	}{
+		"no access policy":  {accessPolicy: nil, expected: nil},
+		"no outbound rules": {accessPolicy: externalPolicyTo(podtypes.ExternalRule{Host: "example.com"}), expected: []string{}},
+		"one target":        {accessPolicy: outboundPolicyTo("second"), expected: []string{"second"}},
+		"several targets":   {accessPolicy: outboundPolicyTo("second", "third"), expected: []string{"second", "third"}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, OutboundTargets(test.accessPolicy))
+		})
+	}
+}

--- a/internal/controllers/outbound_targets_test.go
+++ b/internal/controllers/outbound_targets_test.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kartverket/skiperator/api/common/podtypes"
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	controllercommon "github.com/kartverket/skiperator/internal/controllers/common"
+	"github.com/kartverket/skiperator/pkg/resourceschemas"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func applicationTargeting(namespace, name string, targets ...string) *skiperatorv1alpha1.Application {
+	rules := make([]podtypes.InternalRule, len(targets))
+	for i, target := range targets {
+		rules[i] = podtypes.InternalRule{Application: target}
+	}
+	return &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			AccessPolicy: &podtypes.AccessPolicy{
+				Outbound: &podtypes.OutboundPolicy{Rules: rules},
+			},
+		},
+	}
+}
+
+// The index key is the application name alone. A Service therefore enqueues its
+// dependents in every namespace. Objects that do not reference the Service get
+// no request.
+func TestOutboundTargetRequestsEnqueuesDependentsAcrossNamespaces(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			applicationTargeting("team-a", "first", "second"),
+			applicationTargeting("team-b", "other", "second", "third"),
+			applicationTargeting("team-c", "unrelated", "third"),
+			&skiperatorv1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "team-d", Name: "no-policy"}},
+		).
+		WithIndex(&skiperatorv1alpha1.Application{}, controllercommon.OutboundTargetIndex, func(obj client.Object) []string {
+			return controllercommon.OutboundTargets(obj.(*skiperatorv1alpha1.Application).Spec.AccessPolicy)
+		}).
+		Build()
+
+	reconciler := &ApplicationReconciler{
+		ReconcilerBase: controllercommon.NewReconcilerBase(c, nil, scheme, nil, nil),
+	}
+
+	requests := reconciler.outboundTargetRequests(
+		context.Background(),
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "team-x", Name: "second"}},
+	)
+
+	assert.ElementsMatch(t, []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Namespace: "team-a", Name: "first"}},
+		{NamespacedName: types.NamespacedName{Namespace: "team-b", Name: "other"}},
+	}, requests)
+}

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"time"
 
 	"github.com/kartverket/skiperator/internal/config"
 	"github.com/kartverket/skiperator/pkg/resourceprocessor"
@@ -61,6 +60,13 @@ type SKIPJobReconciler struct {
 
 // TODO Watch applications that are using dynamic port allocation
 func (r *SKIPJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &skiperatorv1beta1.SKIPJob{},
+		common.OutboundTargetIndex, func(obj client.Object) []string {
+			return common.OutboundTargets(obj.(*skiperatorv1beta1.SKIPJob).Spec.AccessPolicy)
+		}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		// GenerationChangedPredicate is now only applied to the SkipJob itself to allow status changes on Jobs/CronJobs to affect reconcile loops
 		For(&skiperatorv1beta1.SKIPJob{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -93,6 +99,10 @@ func (r *SKIPJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Some NetPol entries are not added unless an application is present. If we reconcile all jobs when there has been changes to NetPols, we can assume
 		// that changes to an Applications AccessPolicy will cause a reconciliation of Jobs
 		Watches(&networkingv1.NetworkPolicy{}, handler.EnqueueRequestsFromMapFunc(r.getJobsToReconcile)).
+		// An outbound rule stays unresolved until the Service of the target
+		// application exists. Dependent objects therefore reconcile as soon as
+		// that Service appears or is deleted, and not at the next periodic requeue.
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.outboundTargetRequests)).
 		Complete(r)
 }
 
@@ -234,7 +244,16 @@ func (r *SKIPJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	if skipJob.Status.AccessPolicies == skiperatorv1beta1.INVALIDCONFIG {
 		skipJob.GetStatus().SetSummaryError("Access policy configuration is invalid")
 		r.UpdateStatus(ctx, skipJob)
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		// Internal rules take their ports from the Service of the target
+		// application, so they can become valid with no change to this spec.
+		// The Service watch covers a target that appears or is deleted. This
+		// poll covers only the cases that no watch reports. External rules
+		// depend on the spec alone, so there is nothing to wait for and the
+		// reconcile stops until the spec changes.
+		if !common.IsInternalRulesValid(skipJob.Spec.AccessPolicy) {
+			return reconcile.Result{RequeueAfter: common.AccessPolicyRequeueDelay}, nil
+		}
+		return common.DoNotRequeue()
 	}
 
 	r.EmitNormalEvent(skipJob, "ReconcileEndSuccess", "SKIPJob has been reconciled")
@@ -287,6 +306,28 @@ func (r *SKIPJobReconciler) finalizeSkipJob(skipJob *skiperatorv1beta1.SKIPJob, 
 		}
 	}
 	return nil
+}
+
+// outboundTargetRequests maps a changed Service to the SKIPJobs whose outbound
+// rules target it. The ports of an outbound rule come from the Service of the
+// target application (see setPortsForRules). A dependent object stays in
+// InvalidConfig until that Service exists, and must reconcile as soon as the
+// Service appears or is deleted.
+func (r *SKIPJobReconciler) outboundTargetRequests(ctx context.Context, service client.Object) []reconcile.Request {
+	dependents := &skiperatorv1beta1.SKIPJobList{}
+	if err := r.GetClient().List(ctx, dependents, client.MatchingFields{common.OutboundTargetIndex: service.GetName()}); err != nil {
+		r.Logger.Error(err, "failed to list SKIPJobs that target a Service",
+			"service", client.ObjectKeyFromObject(service))
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(dependents.Items))
+	for i := range dependents.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&dependents.Items[i]),
+		})
+	}
+	return requests
 }
 
 func (r *SKIPJobReconciler) getJobsToReconcile(ctx context.Context, object client.Object) []reconcile.Request {

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"time"
 
 	"github.com/kartverket/skiperator/internal/config"
 	"github.com/kartverket/skiperator/pkg/resourceprocessor"
 	"github.com/kartverket/skiperator/pkg/resourceschemas"
-
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	commontypes "github.com/kartverket/skiperator/api/common"
@@ -231,12 +231,17 @@ func (r *SKIPJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		r.SetErrorState(ctx, skipJob, err, "failed to update conditions", "ConditionsFailure")
 		return common.RequeueWithError(err)
 	}
+	if skipJob.Status.AccessPolicies == skiperatorv1beta1.INVALIDCONFIG {
+		skipJob.GetStatus().SetSummaryError("Access policy configuration is invalid")
+		r.UpdateStatus(ctx, skipJob)
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
 
 	r.EmitNormalEvent(skipJob, "ReconcileEndSuccess", "SKIPJob has been reconciled")
 	skipJob.GetStatus().SetSummarySynced()
 	r.UpdateStatus(ctx, skipJob)
 
-	return common.RequeueWithError(err)
+	return common.DoNotRequeue()
 }
 
 func (r *SKIPJobReconciler) getSKIPJob(ctx context.Context, req reconcile.Request) (*skiperatorv1beta1.SKIPJob, error) {

--- a/tests/application/access-policy-cross-namespace/chainsaw-test.yaml
+++ b/tests/application/access-policy-cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: access-policy-cross-namespace
+spec:
+  skip: false
+  concurrent: false
+  skipDelete: false
+  timeouts:
+    apply: 30s
+    assert: 30s
+    cleanup: 30s
+    delete: 30s
+    error: 30s
+    exec: 30s
+  steps:
+    - try:
+        - apply:
+            file: consumer.yaml
+        - assert:
+            file: consumer-not-ready.yaml
+    - try:
+        - apply:
+            file: target.yaml
+        - assert:
+            file: consumer-ready.yaml

--- a/tests/application/access-policy-cross-namespace/consumer-not-ready.yaml
+++ b/tests/application/access-policy-cross-namespace/consumer-not-ready.yaml
@@ -1,0 +1,14 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: consumer
+status:
+  accessPolicies: InvalidConfig
+  applicationKind: Deployment
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
+    - type: InternalRulesValid
+      status: "False"
+      reason: ApplicationReconciled

--- a/tests/application/access-policy-cross-namespace/consumer-ready.yaml
+++ b/tests/application/access-policy-cross-namespace/consumer-ready.yaml
@@ -1,0 +1,17 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: consumer
+status:
+  accessPolicies: Ready
+  applicationKind: Deployment
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+    - type: InternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled
+    - type: ExternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled

--- a/tests/application/access-policy-cross-namespace/consumer.yaml
+++ b/tests/application/access-policy-cross-namespace/consumer.yaml
@@ -1,0 +1,12 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: consumer
+spec:
+  image: nginxinc/nginx-unprivileged:latest
+  port: 8080
+  accessPolicy:
+    outbound:
+      rules:
+        - application: cross-namespace-target
+          namespace: access-policy-cross-namespace-target

--- a/tests/application/access-policy-cross-namespace/target.yaml
+++ b/tests/application/access-policy-cross-namespace/target.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: access-policy-cross-namespace-target
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: cross-namespace-target
+  namespace: access-policy-cross-namespace-target
+spec:
+  image: nginxinc/nginx-unprivileged:latest
+  port: 8080

--- a/tests/application/access-policy-retry/both-ready.yaml
+++ b/tests/application/access-policy-retry/both-ready.yaml
@@ -1,0 +1,41 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: first
+status:
+  accessPolicies: Ready
+  applicationKind: Deployment
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+      message: Application has been reconciled
+    - type: InternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled
+      message: Internal rules are valid
+    - type: ExternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled
+      message: External rules are valid
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: second
+status:
+  accessPolicies: Ready
+  applicationKind: Deployment
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+      message: Application has been reconciled
+    - type: InternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled
+      message: Internal rules are valid
+    - type: ExternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled
+      message: External rules are valid

--- a/tests/application/access-policy-retry/chainsaw-test.yaml
+++ b/tests/application/access-policy-retry/chainsaw-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: access-policy-retry
+spec:
+  skip: false
+  concurrent: false
+  skipDelete: false
+  steps:
+    - try:
+        - apply:
+            file: first.yaml
+        - assert:
+            file: first-not-ready.yaml
+    - try:
+        - apply:
+            file: second.yaml
+        - assert:
+            file: both-ready.yaml

--- a/tests/application/access-policy-retry/chainsaw-test.yaml
+++ b/tests/application/access-policy-retry/chainsaw-test.yaml
@@ -6,6 +6,13 @@ spec:
   skip: false
   concurrent: false
   skipDelete: false
+  timeouts:
+    apply: 30s
+    assert: 30s
+    cleanup: 30s
+    delete: 30s
+    error: 30s
+    exec: 30s
   steps:
     - try:
         - apply:
@@ -17,3 +24,11 @@ spec:
             file: second.yaml
         - assert:
             file: both-ready.yaml
+    - try:
+        - delete:
+            ref:
+              apiVersion: skiperator.kartverket.no/v1alpha1
+              kind: Application
+              name: second
+        - assert:
+            file: first-not-ready-after-delete.yaml

--- a/tests/application/access-policy-retry/first-not-ready-after-delete.yaml
+++ b/tests/application/access-policy-retry/first-not-ready-after-delete.yaml
@@ -1,0 +1,17 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: first
+status:
+  accessPolicies: InvalidConfig
+  applicationKind: Deployment
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
+    - type: InternalRulesValid
+      status: "False"
+      reason: ApplicationReconciled
+    - type: ExternalRulesValid
+      status: "True"
+      reason: ApplicationReconciled

--- a/tests/application/access-policy-retry/first-not-ready.yaml
+++ b/tests/application/access-policy-retry/first-not-ready.yaml
@@ -1,0 +1,14 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: first
+status:
+  accessPolicies: InvalidConfig
+  applicationKind: Deployment
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
+    - type: InternalRulesValid
+      status: "False"
+      reason: ApplicationReconciled

--- a/tests/application/access-policy-retry/first.yaml
+++ b/tests/application/access-policy-retry/first.yaml
@@ -1,0 +1,14 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: first
+spec:
+  image: nginxinc/nginx-unprivileged:latest
+  port: 8080
+  accessPolicy:
+    inbound:
+      rules:
+        - application: second
+    outbound:
+      rules:
+        - application: second

--- a/tests/application/access-policy-retry/second.yaml
+++ b/tests/application/access-policy-retry/second.yaml
@@ -1,0 +1,14 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: second
+spec:
+  image: nginxinc/nginx-unprivileged:latest
+  port: 8080
+  accessPolicy:
+    inbound:
+      rules:
+        - application: first
+    outbound:
+      rules:
+        - application: first

--- a/tests/skipjob/access-policy-retry/chainsaw-test.yaml
+++ b/tests/skipjob/access-policy-retry/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: skipjob-access-policy-retry
+spec:
+  skip: false
+  concurrent: false
+  skipDelete: false
+  timeouts:
+    apply: 30s
+    assert: 30s
+    cleanup: 30s
+    delete: 30s
+    error: 30s
+    exec: 30s
+  steps:
+    - try:
+        - apply:
+            file: skipjob.yaml
+        - assert:
+            file: skipjob-not-ready.yaml
+    - try:
+        - apply:
+            file: target.yaml
+        - assert:
+            file: skipjob-ready.yaml

--- a/tests/skipjob/access-policy-retry/skipjob-not-ready.yaml
+++ b/tests/skipjob/access-policy-retry/skipjob-not-ready.yaml
@@ -1,0 +1,6 @@
+apiVersion: skiperator.kartverket.no/v1beta1
+kind: SKIPJob
+metadata:
+  name: retry-job
+status:
+  accessPolicies: InvalidConfig

--- a/tests/skipjob/access-policy-retry/skipjob-ready.yaml
+++ b/tests/skipjob/access-policy-retry/skipjob-ready.yaml
@@ -1,0 +1,6 @@
+apiVersion: skiperator.kartverket.no/v1beta1
+kind: SKIPJob
+metadata:
+  name: retry-job
+status:
+  accessPolicies: Ready

--- a/tests/skipjob/access-policy-retry/skipjob.yaml
+++ b/tests/skipjob/access-policy-retry/skipjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: skiperator.kartverket.no/v1beta1
+kind: SKIPJob
+metadata:
+  name: retry-job
+spec:
+  image: "perl:5.34.0"
+  command:
+    - "perl"
+    - "-e"
+    - "print 1"
+  accessPolicy:
+    outbound:
+      rules:
+        - application: retry-target

--- a/tests/skipjob/access-policy-retry/target.yaml
+++ b/tests/skipjob/access-policy-retry/target.yaml
@@ -1,0 +1,7 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: retry-target
+spec:
+  image: image
+  port: 8080


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Changed

- Requeue `Application` and `SKIPJob` reconciliation while internal access-policy rules remain invalid.
- Watch target `Service` resources and requeue dependent `Application` and `SKIPJob` resources when targets appear or are deleted.
- Stop periodic requeues when only external access-policy rules are invalid.
- Add Chainsaw coverage for access-policy recovery and cross-namespace targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->